### PR TITLE
Auto expand filters if it is from URL

### DIFF
--- a/e2e_tests/tests/ActionFilters/FromURL.js
+++ b/e2e_tests/tests/ActionFilters/FromURL.js
@@ -5,6 +5,7 @@ module.exports = {
       .waitForElementVisible('body')
       .pause(2000)
       .waitForElementVisible('.network')
+      .assert.visible('#btn-wordCount')
       .pause(3000)
       .elements('css selector', '.ais-Hits__books-book', (bookElement) => {
         bookElement.value.forEach((v) => {
@@ -50,6 +51,7 @@ module.exports = {
                 .waitForElementVisible('body')
                 .pause(3000)
                 .waitForElementVisible('.subjects')
+                .assert.visible('#filter-about > div.v-list-group__items > div:nth-child(2)')
                 .elements('css selector', '.subjects', (bookElement) => {
                   bookElement.value.forEach((v) => {
                     if (!v.hasOwnProperty('ELEMENT')) {
@@ -95,6 +97,7 @@ module.exports = {
                 .waitForElementVisible('body')
                 .pause(3000)
                 .waitForElementVisible('.publisher')
+                .assert.visible('#filter-publisher_name > div.v-list-group__items > div:nth-child(2)')
                 .elements('css selector', '.publisher', (bookElement) => {
                   bookElement.value.forEach((v) => {
                     if (!v.hasOwnProperty('ELEMENT')) {
@@ -120,6 +123,7 @@ module.exports = {
       .waitForElementVisible('body')
       .pause(2000)
       .waitForElementVisible('#filter-lastUpdated')
+      .assert.visible('#btn-date-lastUpdated')
       .waitForElementVisible('.network')
       .click('#filter-lastUpdated')
       .elements('css selector', '.ais-Hits__books-book', (bookElement) => {

--- a/src/components/filters/commons/DateRangeFilters.vue
+++ b/src/components/filters/commons/DateRangeFilters.vue
@@ -2,7 +2,7 @@
   <v-list-group
     :id="'filter-' + field"
     sub-group
-    :value="false"
+    :value="isFiltered"
   >
     <template #activator>
       <v-list-item-title>{{ uppercase(title) }}</v-list-item-title>
@@ -119,6 +119,7 @@ export default {
     dateEndFormatted: '',
     start: false,
     end: false,
+    isFiltered: false
   }),
   watch: {
     dateStart (val) {
@@ -132,6 +133,7 @@ export default {
       handler(q) {
         let query = {...q};
         if (query[this.alias] !== undefined) {
+          this.isFiltered = true;
           let d1, d2, dateObjFrom, dateObjTo;
           let dates = query[this.alias].split('&&');
           if (dates.length === 1) {

--- a/src/components/filters/commons/ExcludedFilters.vue
+++ b/src/components/filters/commons/ExcludedFilters.vue
@@ -2,7 +2,7 @@
   <v-list-group
     :id="'filter-' + field"
     sub-group
-    :value="false"
+    :value="itemsFiltered"
   >
     <template #activator>
       <v-list-item-title>{{ uppercase(title) }}</v-list-item-title>
@@ -152,7 +152,8 @@ export default {
       alias: this.$store.state.SClient.allowedFilters[this.field].alias,
       empty: this.$store.state.SClient.allowedFilters[this.field].empty,
       emptyFieldCount: 0,
-      textEmpty: 'No value / empty'
+      textEmpty: 'No value / empty',
+      itemsFiltered: false
     };
   },
   watch: {
@@ -164,6 +165,12 @@ export default {
             this.emptyFieldCount = filters[this.empty][i].count;
           }
         }
+      }
+    },
+    '$store.state.SClient.filtersExcluded': {
+      deep: true,
+      handler() {
+        this.itemsFiltered = typeof(this.$store.state.SClient.filtersExcluded[this.field]) !== 'undefined' && this.$store.state.SClient.filtersExcluded[this.field].length > 0;
       }
     }
   },
@@ -206,7 +213,7 @@ export default {
         value = false;
       }
       return typeof(this.$store.state.SClient.filtersExcluded[field]) !== 'undefined' &&
-                    this.$store.state.SClient.filtersExcluded[field].find(v => v.value === value && v.exclude === exclude) !== undefined;
+        this.$store.state.SClient.filtersExcluded[field].find(v => v.value === value && v.exclude === exclude) !== undefined;
     },
     clearFilters() {
       let query = {...this.$route.query};

--- a/src/components/filters/commons/NumericFilters.vue
+++ b/src/components/filters/commons/NumericFilters.vue
@@ -2,7 +2,7 @@
   <v-list-group
     :id="'filter-' + field"
     sub-group
-    :value="false"
+    :value="itemsFiltered"
   >
     <template #activator>
       <v-list-item-title>{{ uppercase(title) }}</v-list-item-title>
@@ -82,8 +82,33 @@ export default {
         min: 0,
         max: 0,
         alias: ''
-      }
+      },
+      itemsFiltered: false
     };
+  },
+  watch: {
+    '$store.state.SClient.filtersExcluded': {
+      deep: true,
+      handler(filters) {
+        if (
+          typeof(filters[this.field]) !== 'undefined' &&
+          filters[this.field].length > 0
+        ) {
+          this.itemsFiltered = true;
+          for (let i = 0; i < filters[this.field].length; i++) {
+            if (filters[this.field][i].operator === '>=') {
+              this.number.min = filters[this.field][i].value;
+            } else {
+              this.number.max = filters[this.field][i].value;
+            }
+          }
+        } else {
+          this.number.min = 0;
+          this.number.max = 0;
+          this.itemsFiltered = false;
+        }
+      }
+    }
   },
   mounted() {
     this.alias = this.$store.state.SClient.allowedFilters[this.field].alias;

--- a/src/main.js
+++ b/src/main.js
@@ -37,9 +37,8 @@ router.beforeEach((to, from, next) => {
       store.state.SClient.filtersExcluded = {};
       store.state.SClient.notFilters = [];
       store.state.SClient.numericFilters = [];
-    } else {
-      store.commit('setFiltersFromQueryParams', query);
     }
+    store.commit('setFiltersFromQueryParams', query);
     store.commit('setFacetFilters', store.state.SClient.notFilters);
     store.commit('setKeepFacets', Object.keys(store.state.SClient.filtersExcluded));
     store.dispatch('getStats', index);


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/113 (item # 2)

This change auto expand the filter group when the filter is applied from an URL.
Also, fix the following bug:
1. Apply a numeric filter (like _word count_ or _storage size_ filter), from interface or URL.
2. Clear the filter clear the filters clicking on **"Clear refinements"** red button.
3. Filter is deleted bug book cards are not updated.
This is a bug related to the routing management.

### How to test these changes
For auto expand feature:
- Apply a filter from URL, adding at the end of the URL filters like:
  - _?words=>%3D2000%26%26<%3D5000_
  - ?updated=>%3D1596240000%26%26<%3D1920055338&license=CC%20BY
- Check if group filters applied are expanded in the sidebar

For test the fixed bug mentioned above:
- Apply a numeric filter like Word Count or Storage Size
- Click on "Clear refinement" button
- Make sure filter was deleted and book cards were updated properly.