### PR TITLE
Fix E2E tests for production deployment

### DIFF
--- a/e2e_tests/tests/App/Pagination.js
+++ b/e2e_tests/tests/App/Pagination.js
@@ -18,6 +18,7 @@ module.exports = {
         if (totalPages > parseInt(totalPages)) {
           totalPages = parseInt(totalPages) + 1;
         }
+        totalPages = (totalPages > 7) ? 7 : totalPages;
         browser.elements('css selector', '.ais-Pagination-link', (elem) => {
           let pages = (elem.value.length / 2) - 4;
           browser.assert.ok(totalPages === pages, 'Pages expected: ' + totalPages + '. Pages shown: ' + pages);

--- a/e2e_tests/tests/App/Search.js
+++ b/e2e_tests/tests/App/Search.js
@@ -20,40 +20,40 @@ module.exports = {
         });
       });
   },
-  'Searching by publisher (partial string) and literal string from random description' (browser) {
+  'Searching by subject (partial string) and literal string from random title' (browser) {
     browser
       .url(process.env.HOST_TEST)
       .waitForElementVisible('body')
       .pause(4000)
       .assert.visible('#search-book')
-      .element('css selector', '.v-card--item.description',  (elem) => {
+      .element('css selector', '#book-list > div > div > div > div:nth-child(2) > div > div > div > div.col.col-9 > div.v-card__title',  (elem) => {
         if (!elem.value.hasOwnProperty('ELEMENT')) {
           elem.value.ELEMENT = Object.values(elem.value)[0];
         }
-        browser.elementIdText(elem.value.ELEMENT, (description) => {
-          let searchDescription = description.value.split(' ').slice(0, 2).join(' ');
-          let stringToSearch = '"' + searchDescription + '"';
+        browser.elementIdText(elem.value.ELEMENT, (title) => {
+          let searchTitle = title.value.split(' ').slice(0, 2).join(' ');
+          let stringToSearch = '"' + searchTitle + '"';
           browser
-            .element('css selector', '.v-card--item.publisher',  (elem) => {
+            .element('css selector', '.v-card--item.subject',  (elem) => {
               if (!elem.value.hasOwnProperty('ELEMENT')) {
                 elem.value.ELEMENT = Object.values(elem.value)[0];
               }
-              browser.elementIdText(elem.value.ELEMENT, (publisher) => {
-                stringToSearch += ' pub:"' + publisher.value.substring(0, 3) + '"';
+              browser.elementIdText(elem.value.ELEMENT, (subject) => {
+                stringToSearch += ' subj:"' + subject.value.substring(0, 3) + '"';
                 browser.setValue('#search-book', stringToSearch)
                   .click('button[id=search-button]')
                   .pause(2000)
                   .waitForElementVisible('.ais-Hits__books')
-                  .elements('css selector', '.v-card--item.publisher', (elems) => {
+                  .elements('css selector', '.v-card--item.subject', (elems) => {
                     elems.value.forEach((elem) => {
                       if (!elem.hasOwnProperty('ELEMENT')) {
                         elem.ELEMENT = Object.values(elem)[0];
                       }
-                      browser.elementIdText(elem.ELEMENT, (publisherCard) => {
+                      browser.elementIdText(elem.ELEMENT, (subjectCard) => {
                         browser
                           .assert.ok(
-                            publisherCard.value.search(publisher.value.substring(0, 3)) >= 0,
-                            'Book with publisher ' + publisherCard.value + '. It contains publisher string ' + publisher.value.substring(0, 3)
+                            subjectCard.value.search(subject.value.substring(0, 3)) >= 0,
+                            'Book with subj ' + subjectCard.value + '. It contains title string ' + title.value.substring(0, 3)
                           );
                       });
                     });

--- a/e2e_tests/tests/App/SortBy.js
+++ b/e2e_tests/tests/App/SortBy.js
@@ -60,14 +60,17 @@ module.exports = {
           }).perform((done) => {
             browser.elementIdText(elementId, (words) => {
               words.value = words.value.toLowerCase();
-              if (previousName === '') {
-                previousName = words.value;
-              } else {
-                browser.assert.ok(
-                  previousName <= words.value,
-                  'Book name: ' + words.value + '. Correct name order for this card.'
-                );
-                previousName = words.value;
+              if (words.value[0].match(/[a-z]/i)) {
+                if (previousName === '') {
+                  previousName = words.value;
+                } else {
+                  let lexOrder = previousName.localeCompare(words.value) < 0 ? true : previousName <= words.value;
+                  browser.assert.ok(
+                    lexOrder,
+                    'Book name: ' + words.value + '. Correct name order for this card.'
+                  );
+                  previousName = words.value;
+                }
               }
             });
             done();


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/342

This change fix:
- Maximum buttons page allowed by default is 7. If there is more than 7 pages, additional buttons will be displayed to see following pages.
- Search string that contains `"` using literal search (literal search is surrounded with double quotes) generates a inconsistency. E2E test was changes searching by subject instead description.
- Sorting logic for Algolia is different Javascript ordering logic, specially for special characters. In E2E tests for Sort by title action changes, if title contains special characters is not considered for sorting logic to avoid discrepancies.

This changes will allow us to add E2E tests to new AWS pipeline for production.