### PR TITLE
Update welcome-header text and link colour

### DIFF
--- a/src/components/WelcomeHeader.vue
+++ b/src/components/WelcomeHeader.vue
@@ -4,7 +4,9 @@
     <p>
       This directory provides an index of <strong>{{ $store.state.stats.totalBooks }}</strong> books published across
       <strong>{{ $store.state.stats.totalNetworks }}</strong> Pressbooks networks. Search and filter books by keyword,
-      subject matter, license, and more.
+      subject matter, license, and more. See
+      <a href="https://networkmanagerguide.pressbooks.com/chapter/how-to-use-the-pressbooks-directory/">our guide for
+        more detailed instructions</a> on using the Pressbooks Directory to find books of interest.
     </p>
     <!-- eslint-disable vue/no-v-html -->
     <p
@@ -18,6 +20,7 @@
 
 <script>
 import Searchbox from './Searchbox';
+
 export default {
   name: 'WelcomeHeader',
   components: {Searchbox},

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -40,6 +40,10 @@
       font: 1.125rem $font-secondary;
       color: $pb-blue;
       margin-bottom: 1.5rem;
+
+      a {
+        color: $pb-red;
+      }
     }
 
     .searchbox {


### PR DESCRIPTION
Adds a link to our guide chapter to welcome text and changes link colour for links in welcome header to Pressbooks red.