### PR TITLE
Change clear button text

### DIFF
--- a/src/components/filters/commons/DateRangeFilters.vue
+++ b/src/components/filters/commons/DateRangeFilters.vue
@@ -87,7 +87,7 @@
           tile
           @click="clearFilters()"
         >
-          CLEAR
+          Clear Filter
         </v-btn>
       </div>
     </v-list-item>

--- a/src/components/filters/commons/ExcludedFilters.vue
+++ b/src/components/filters/commons/ExcludedFilters.vue
@@ -113,7 +113,7 @@
           tile
           @click="clearFilters()"
         >
-          CLEAR
+          Clear Filter
         </v-btn>
       </div>
     </v-list-item>

--- a/src/components/filters/commons/NumericFilters.vue
+++ b/src/components/filters/commons/NumericFilters.vue
@@ -51,7 +51,7 @@
           tile
           @click="clearFilters()"
         >
-          CLEAR
+          Clear Filter
         </v-btn>
       </div>
     </v-list-item>

--- a/src/styles/filters.scss
+++ b/src/styles/filters.scss
@@ -48,6 +48,7 @@
     }
     &-button {
       background-color: $pb-red;
+      text-transform: uppercase;
     }
     .v-btn {
       background: $pb-light !important;


### PR DESCRIPTION
Changes 'Clear' button text in facets to read 'Clear Filter'. Changes method for making this text all caps to use text-transform CSS property. Fix for https://github.com/pressbooks/pressbooks-book-directory-fe/issues/139