### PR TITLE
Fix search facet after applying a filter

### DIFF
--- a/e2e_tests/tests/CommonFilters/ExcludedFilters.js
+++ b/e2e_tests/tests/CommonFilters/ExcludedFilters.js
@@ -147,5 +147,92 @@ module.exports = {
           });
         });
       }).end();
+  },
+  'Perform a search in networks filter, apply the filter and check those are not changed' (browser) {
+    browser
+      .url(process.env.HOST_TEST)
+      .waitForElementVisible('body')
+      .waitForElementVisible('#filter-networkName')
+      .click('#filter-networkName')
+      .getText('#filter-networkName > div.v-list-group__items > div:nth-child(4) > div.v-list-item__content', (networkText3) => {
+        const secondText = networkText3.value.substr(0, 4);
+        browser.getText('#filter-networkName > div.v-list-group__items > div:nth-child(3) > div.v-list-item__content', (networkText) => {
+          if (networkText.value && networkText.value.length > 1 && networkText.value.search('No value / empty') < 0) {
+            const searchText = networkText.value.substr(0, 2);
+            let networksFiltered = [];
+            browser
+              .setValue('#search-filter-networkName', searchText)
+              .pause(2000)
+              .elements('css selector', '#filter-networkName > div.v-list-group__items', (networksElement) => {
+                networksElement.value.forEach((v) => {
+                  if (!v.hasOwnProperty('ELEMENT')) {
+                    v.ELEMENT = Object.values(v)[0];
+                  }
+                  browser.elementIdText(v.ELEMENT, (networkElement) => {
+                    networksFiltered.push(networkElement.value);
+                  });
+                });
+              }).perform((done) => {
+              // Filter any of the networks listed
+                browser
+                  .click('#filter-networkName > div.v-list-group__items > div:nth-child(3) > div.v-list-item__action > div > button.v-btn.v-btn--flat.v-btn--icon.v-btn--round.theme--light.v-size--default.include')
+                  .pause(3000)
+                  .elements('css selector', '#filter-networkName > div.v-list-group__items', (netElements) => {
+                    netElements.value.forEach((v) => {
+                      if (!v.hasOwnProperty('ELEMENT')) {
+                        v.ELEMENT = Object.values(v)[0];
+                      }
+                      browser.elementIdText(v.ELEMENT, (netEl) => {
+                        browser.assert.ok(
+                          networksFiltered.indexOf(netEl.value) >= 0,
+                          'Network item is present in the list just like before apply the filter.'
+                        );
+                      });
+                    });
+                  }).perform((doneFirstCheck) => {
+                    networksFiltered = [];
+                    browser
+                      .click('#clear-networkName')
+                      .pause(2000)
+                      .click('#filter-networkName')
+                      .setValue('#search-filter-networkName', secondText)
+                      .pause(2000)
+                      .elements('css selector', '#filter-networkName > div.v-list-group__items', (networksElement) => {
+                        networksElement.value.forEach((v) => {
+                          if (!v.hasOwnProperty('ELEMENT')) {
+                            v.ELEMENT = Object.values(v)[0];
+                          }
+                          browser.elementIdText(v.ELEMENT, (networkElement) => {
+                            networksFiltered.push(networkElement.value);
+                          });
+                        });
+                      }).perform((done2) => {
+                        // Filter any of the networks listed
+                        browser
+                          .click('#filter-networkName > div.v-list-group__items > div:nth-child(3) > div.v-list-item__action > div > button.v-btn.v-btn--flat.v-btn--icon.v-btn--round.theme--light.v-size--default.include')
+                          .pause(3000)
+                          .elements('css selector', '#filter-networkName > div.v-list-group__items', (netElements) => {
+                            netElements.value.forEach((v) => {
+                              if (!v.hasOwnProperty('ELEMENT')) {
+                                v.ELEMENT = Object.values(v)[0];
+                              }
+                              browser.elementIdText(v.ELEMENT, (netEl) => {
+                                browser.assert.ok(
+                                  networksFiltered.indexOf(netEl.value) >= 0,
+                                  'Network item is present in the list after apply the filter twice just like before apply the filter the first time.'
+                                );
+                              });
+                            });
+                          });
+                        done2();
+                      });
+                    doneFirstCheck();
+                  });
+                done();
+              });
+            return true;
+          }
+        });
+      });
   }
 };

--- a/src/components/filters/commons/ExcludedFilters.vue
+++ b/src/components/filters/commons/ExcludedFilters.vue
@@ -112,6 +112,7 @@
         <v-btn
           tile
           @click="clearFilters()"
+          :id="'clear-' + field"
         >
           Clear Filter
         </v-btn>
@@ -153,7 +154,8 @@ export default {
       empty: this.$store.state.SClient.allowedFilters[this.field].empty,
       emptyFieldCount: 0,
       textEmpty: 'No value / empty',
-      itemsFiltered: false
+      itemsFiltered: false,
+      filterApplied: false
     };
   },
   watch: {
@@ -165,6 +167,10 @@ export default {
             this.emptyFieldCount = filters[this.empty][i].count;
           }
         }
+        if (this.filterApplied && this.stringSearch.length > 0) {
+          this.searchForItems();
+        }
+        this.filterApplied = false;
       }
     },
     '$store.state.SClient.filtersExcluded': {
@@ -218,9 +224,11 @@ export default {
     clearFilters() {
       let query = {...this.$route.query};
       delete query[this.alias];
+      this.stringSearch = '';
       this.$router.replace({ query });
     },
     applyFilter(itemValue, exclude) {
+      this.filterApplied = true;
       let query = {...this.$route.query}, value;
       value = exclude ? '-' + itemValue : itemValue;
       if (typeof(query[this.alias]) === 'undefined') {


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/140

This change performs the searchItems action (the action that searches within facets in the ExcludedFilters component) right after applying a new filter in ExcludedFilters. This action is made on the component's watch to ensure the action is made intermediately if the stringSearch (variable model for input text) contains 1 or more characters.

Also, the "Clear Filter" action at the bottom of each filter group did not clean the text input. This change implement the deletion of the string in the input right after the clear filter was applied.

E2E use case implemented:
- Search in network facet
- Apply a network filter found
- Check list of networks facet filtered to ensure the list is still the same
- Clear filters, and search again with other pattern
- Apply a network filter found
- Check list of networks facet filtered again, to ensure the list is still the same.