### PR TITLE
Add collection header section

### DIFF
--- a/e2e_tests/tests/App/Collections.js
+++ b/e2e_tests/tests/App/Collections.js
@@ -1,0 +1,32 @@
+module.exports = {
+  async 'Perform a search by network and confirm collection of books are the same after the search action' (browser) {
+    await browser
+      .url(process.env.HOST_TEST);
+    await browser
+      .waitForElementVisible('body');
+    await browser.pause(4000);
+    await browser.assert.visible('#search-book');
+    const isVisible = await browser
+      .isVisible({
+        selector: '#special-header-collections > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a',
+        index: 0,
+        suppressNotFoundErrors: true
+      });
+    if (parseInt(isVisible.status) !== -1) {
+      const networkName = await browser.getText('.network');
+      let collectionElement = await browser.getText('#special-header-collections > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a');
+      if (collectionElement.value) {
+        let collectionTitle = collectionElement.value;
+        await browser.setValue('#search-book', networkName);
+        await browser.click('button[id=search-button]');
+        await browser.waitForElementVisible('.ais-Hits__books');
+        await browser.pause(2000);
+        await browser.assert.containsText(
+          '#special-header-collections > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a',
+          collectionTitle
+        );
+        await browser.end();
+      }
+    }
+  }
+};

--- a/e2e_tests/tests/App/FeaturedBooks.js
+++ b/e2e_tests/tests/App/FeaturedBooks.js
@@ -1,56 +1,47 @@
 module.exports = {
-  'Perform a search by network and confirm featured books are the same after the search action' (browser) {
-    browser
-      .url(process.env.HOST_TEST)
-      .waitForElementVisible('body')
-      .pause(4000)
-      .assert.visible('#search-book')
-      .element('css selector', '.network', (elem) => {
-        if (!elem.value.hasOwnProperty('ELEMENT')) {
-          elem.value.ELEMENT = Object.values(elem.value)[0];
-        }
-        browser.elementIdText(elem.value.ELEMENT, async function(network) {
-          let networkName = network.value;
-          const elemTitle = await browser
-            .isVisible({
-              selector: '.v-card__title.v-card__title--featuredbook > a',
-              index: 1,
-              suppressNotFoundErrors: true
-            });
-          if (elemTitle.value) {
-            if (!elemTitle.value.hasOwnProperty('ELEMENT')) {
-              elemTitle.value.ELEMENT = Object.values(elemTitle.value)[0];
-            }
-            browser.elementIdText(elemTitle.value.ELEMENT, (featureBooksTitle) => {
-              let featuredBook = featureBooksTitle.value;
-              browser.setValue('#search-book', networkName)
-                .click('button[id=search-button]')
-                .waitForElementVisible('.ais-Hits__books')
-                .pause(2000)
-                .assert.containsText(
-                  '.v-card__title.v-card__title--featuredbook > a',
-                  featuredBook
-                )
-                .end();
-            });
-          }
-        });
+  async 'Perform a search by network and confirm featured books are the same after the search action' (browser) {
+    await browser
+      .url(process.env.HOST_TEST);
+    await browser
+      .waitForElementVisible('body');
+    await browser.pause(4000);
+    await browser.assert.visible('#search-book');
+    const isVisible = await browser
+      .isVisible({
+        selector: '#special-header-featuredBooks > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a',
+        index: 0,
+        suppressNotFoundErrors: true
       });
+    if (parseInt(isVisible.status) !== -1) {
+      const networkName = await browser.getText('.network');
+      let linkFeatureElement = await browser.getText('#special-header-featuredBooks > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a');
+      if (linkFeatureElement.value) {
+        let featureBooksTitle = linkFeatureElement.value;
+        await browser.setValue('#search-book', networkName);
+        await browser.click('button[id=search-button]');
+        await browser.waitForElementVisible('.ais-Hits__books');
+        await browser.pause(2000);
+        await browser.assert.containsText(
+          '#special-header-featuredBooks > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a',
+          featureBooksTitle
+        );
+        await browser.end();
+      }
+    }
   },
   async 'Check the link in the title for a featured book' (browser) {
-    browser.url(process.env.HOST_TEST);
-    const elemTitle = await browser.isVisible({
-      selector: '.v-card__title.v-card__title--featuredbook > a',
-      index: 1,
+    await browser.url(process.env.HOST_TEST);
+    const isVisible = await browser.isVisible({
+      selector: '#special-header-featuredBooks > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a',
+      index: 0,
       suppressNotFoundErrors: true
     });
-    if (elemTitle.value) {
-      browser.click('div.v-card__title.v-card__title--featuredbook > a');
-      browser.windowHandles(function(result) {
-        const handle = result.value[1];
-        browser.switchWindow(handle);
-        browser.expect.url().to.not.contain(process.env.HOST_TEST);
-      });
+    if (parseInt(isVisible.status) !== -1) {
+      await browser.click('#special-header-featuredBooks > div > div.offset-1.ml-auto.specialheader--col.col-lg-2.col > div > div.v-card__title.v-card__title--specialheader > a');
+      const result = await browser.windowHandles();
+      const handle = result.value[1];
+      browser.switchWindow(handle);
+      browser.expect.url().to.not.contain(process.env.HOST_TEST);
       browser.end();
     }
   }

--- a/src/components/WelcomeHeader.vue
+++ b/src/components/WelcomeHeader.vue
@@ -15,17 +15,19 @@
     />
     <!--eslint-enable-->
     <featured-books v-if="$vuetify.breakpoint.width > 700" />
+    <collections v-if="$vuetify.breakpoint.width > 700" />
     <searchbox />
   </v-container>
 </template>
 
 <script>
 import Searchbox from './Searchbox';
-import FeaturedBooks from './featuredBook/FeaturedBooks';
+import FeaturedBooks from './additionalCards/FeaturedBooks';
+import Collections from './additionalCards/Collections';
 
 export default {
   name: 'WelcomeHeader',
-  components: {Searchbox, FeaturedBooks},
+  components: {Collections, Searchbox, FeaturedBooks},
   data() {
     return {
       additionalText: (process.env.VUE_APP_HEADER_ADDITIONAL_TEXT) ? process.env.VUE_APP_HEADER_ADDITIONAL_TEXT : false,

--- a/src/components/additionalCards/Collections.vue
+++ b/src/components/additionalCards/Collections.vue
@@ -1,0 +1,16 @@
+<template>
+  <specials-header
+    title="Featured Collections"
+    store-name="collections"
+    store-property="collectionHeaderCardObjects"
+    store-action="getCollections"
+  />
+</template>
+
+<script>
+import SpecialsHeader from './commons/SpecialsHeader';
+export default {
+  name: 'Collections',
+  components: {SpecialsHeader}
+};
+</script>

--- a/src/components/additionalCards/FeaturedBooks.vue
+++ b/src/components/additionalCards/FeaturedBooks.vue
@@ -1,0 +1,16 @@
+<template>
+  <specials-header
+    title="Featured Books"
+    store-name="featuredBooks"
+    store-property="books"
+    store-action="getFeaturedBooks"
+  />
+</template>
+
+<script>
+import SpecialsHeader from './commons/SpecialsHeader';
+export default {
+  name: 'FeaturedBooks',
+  components: {SpecialsHeader}
+};
+</script>

--- a/src/components/additionalCards/commons/SpecialsBookCard.vue
+++ b/src/components/additionalCards/commons/SpecialsBookCard.vue
@@ -1,32 +1,32 @@
 <template>
   <v-card
-    class="welcome-header--featuredbook--card"
+    class="welcome-header--specialheader--card"
     :elevation="0"
   >
     <book-cover
-      :image="featuredBook.image"
+      :image="card.image"
       :min-height="240"
       :max-height="240"
     />
-    <v-card-title class="v-card__title--featuredbook">
+    <v-card-title class="v-card__title--specialheader">
       <a
-        :href="featuredBook.url"
-        :title="featuredBook.name"
+        :href="card.url"
+        :title="card.name"
         target="_blank"
       >
-        {{ truncateTitle(featuredBook.name) }}
+        {{ truncateTitle(card.name) }}
       </a>
     </v-card-title>
   </v-card>
 </template>
 
 <script>
-import BookCover from '../commons/BookCover';
+import BookCover from '../../commons/BookCover';
 export default {
-  name: 'FeaturedBookCard',
+  name: 'SpecialsBookCard',
   components: {BookCover},
   props: {
-    featuredBook: {
+    card: {
       type: Object,
       default () { return {}; }
     }

--- a/src/components/additionalCards/commons/SpecialsHeader.vue
+++ b/src/components/additionalCards/commons/SpecialsHeader.vue
@@ -1,27 +1,28 @@
 <template>
   <v-container
-    v-if="$store.state.featuredBooks.books.length > 4"
-    class="pa-0 featuredbook"
+    v-if="$store.state[storeName][storeProperty].length > 4"
+    :id="'special-header-' + storeName"
+    :class="'pa-0 specialheader ' + 'specialheader--' + storeName"
   >
-    <h2>Featured Books</h2>
+    <h2>{{ title }}</h2>
     <v-row
       v-if="$vuetify.breakpoint.width > 1264"
       no-gutters
       justify="center"
     >
       <v-col
-        class="offset-1 ml-auto featuredbook--col"
+        class="offset-1 ml-auto specialheader--col"
         :lg="2"
       >
-        <featured-book-card :featured-book="$store.state.featuredBooks.books[0]" />
+        <specials-book-card :card="$store.state[storeName][storeProperty][0]" />
       </v-col>
       <v-col
-        v-for="(featuredBook, n) in $store.state.featuredBooks.books.slice(1, 5)"
+        v-for="(card, n) in $store.state[storeName][storeProperty].slice(1, 5)"
         :key="n"
         :lg="2"
-        class="ml-auto featuredbook--col"
+        class="ml-auto specialheader--col"
       >
-        <featured-book-card :featured-book="featuredBook" />
+        <specials-book-card :card="card" />
       </v-col>
     </v-row>
     <v-row
@@ -38,11 +39,11 @@
             no-gutters
           >
             <v-col
-              v-for="(featuredBook, n) in $store.state.featuredBooks.books.slice(1, 4)"
+              v-for="(card, n) in $store.state[storeName][storeProperty].slice(1, 4)"
               :key="n"
               :lg="4"
             >
-              <featured-book-card :featured-book="featuredBook" />
+              <specials-book-card :card="card" />
             </v-col>
           </v-row>
         </v-container>
@@ -58,13 +59,13 @@
             justify="center"
           >
             <v-col
-              v-for="(featuredBook, n) in $store.state.featuredBooks.books.slice(3, 5)"
+              v-for="(card, n) in $store.state[storeName][storeProperty].slice(3, 5)"
               :key="n"
               :lg="6"
               :md="4"
               :sm="4"
             >
-              <featured-book-card :featured-book="featuredBook" />
+              <specials-book-card :card="card" />
             </v-col>
           </v-row>
         </v-container>
@@ -74,14 +75,32 @@
 </template>
 
 <script>
-import FeaturedBookCard from './FeaturedBookCard';
+import SpecialsBookCard from './SpecialsBookCard';
 
 export default {
-  name: 'FeaturedBooks',
-  components: {FeaturedBookCard},
+  name: 'SpecialsHeader',
+  components: {SpecialsBookCard},
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    storeName: {
+      type: String,
+      default: ''
+    },
+    storeProperty: {
+      type: String,
+      default: ''
+    },
+    storeAction: {
+      type: String,
+      default: ''
+    },
+  },
   mounted() {
     let index = this.$store.state.SClient.searchClient.initIndex(this.$store.state.SClient.indexName);
-    this.$store.dispatch('getFeaturedBooks', index);
+    this.$store.dispatch(this.storeAction, index);
   }
 };
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import SClient from './modules/searchclient';
 import config from './modules/config';
 import stats from './modules/stats';
 import featuredBooks from './modules/featuredBooks';
+import collections from './modules/collections';
 
 Vue.use(Vuex);
 
@@ -12,6 +13,7 @@ export const store = new Vuex.Store({
     SClient,
     config,
     stats,
-    featuredBooks
+    featuredBooks,
+    collections
   }
 });

--- a/src/store/modules/collections.js
+++ b/src/store/modules/collections.js
@@ -1,0 +1,50 @@
+let collections = {
+  collections: [],
+  collectionHeaderCardObjects: [],
+  collectionsFacetName: 'collections',
+  coverImageFacetName: 'coverImageCollections'
+};
+
+export default {
+  state: collections,
+  mutations: {
+    setCollections(state, collections) {
+      state.collections = collections;
+    },
+    setCollectionHeaderCards(state, cards) {
+      state.collectionHeaderCardObjects = cards;
+    }
+  },
+  actions: {
+    getCollections(context, index) {
+      return index.search('', {facets: context.state.collectionsFacetName}).then(function (responseCollectionsFacet) {
+        if (
+          responseCollectionsFacet.hasOwnProperty('facets') &&
+          typeof responseCollectionsFacet.facets[context.state.collectionsFacetName] !== 'undefined'
+        ) {
+          const collections = Object.keys(responseCollectionsFacet.facets[context.state.collectionsFacetName]);
+          if (collections.length > 0) {
+            context.commit('setCollections', collections);
+            const collectionFacetFiltersParameter = collections.map((collectionString) => {
+              return context.state.coverImageFacetName + ':' + collectionString;
+            });
+            return index.search('', { facetFilters: [collectionFacetFiltersParameter] }).then(function (coverImagesResponse) {
+              if (coverImagesResponse.hasOwnProperty('hits')) {
+                context.commit(
+                  'setCollectionHeaderCards',
+                  coverImagesResponse.hits.map((book) => {
+                    return {
+                      image: book.image,
+                      name: book[context.state.coverImageFacetName][0],
+                      url: ''
+                    };
+                  })
+                );
+              }
+            });
+          }
+        }
+      });
+    }
+  }
+};

--- a/src/store/modules/featuredBooks.js
+++ b/src/store/modules/featuredBooks.js
@@ -1,5 +1,3 @@
-import helpers from '../helpers';
-
 let featuredBooks = {
   books: []
 };

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -69,11 +69,11 @@
 
     }
 
-    &--featuredbook--card {
+    &--specialheader--card {
       max-height: 25rem;
       max-width: 11rem;
 
-      .v-card__title--featuredbook {
+      .v-card__title--specialheader {
         padding: 16px 0;
         line-height: 1.3;
         font-size: 1.15rem;
@@ -92,7 +92,7 @@
 
 .v-card {
   &__title {
-    &--featuredbook {
+    &--specialheader {
       word-break: break-word;
     }
   }
@@ -103,7 +103,7 @@
   margin: 0;
 }
 
-.featuredbook {
+.specialheader {
   &--col {
     min-width: 20%;
   }
@@ -112,7 +112,8 @@
   }
 }
 
-.v-list-group::after, .featuredbook::before, .featuredbook::after {
+
+.v-list-group::after, .specialheader--featuredBooks::before, .specialheader--collections::before, .specialheader--collections::after {
   display: inline-block;
   content: "";
   border-top: 1px solid #e6e6e6;


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/153

This change adds the new "Collections" section in the header, just like "Featured Books".
There are 4 new components and FeaturedBooks component was re-factorized using the new structure.
- SpecialsHeaders: a common component used for FeaturedBooks and Collections. It represents the entire header section for both.
- SpecialsBookCard: a common component used as a card for FeaturedBooks and Collections. It represents each card in each header section.
- FeaturedBooks: previous FeaturedBooks component was replaced for this one. It makes use of SpecialHeaders
- Collections: Just like FeaturedBooks but with different parameters that indicates the store variables needed to be used in SpecialsHeaders and SpecialsBookCard components.

Also, a new store was added: `collections`. This store manages the `collections` and `coverImageCollections` Algolia's facets.

### How to test
- Set `dev_pressbooks_directory` in your `VUE_APP_ALGOLIA_INDEX` env variable in your local environment.
- You will be able to see the new collections section
- Run E2E associated tests: `npm run e2e -- --env firefox --test e2e_tests/tests/App/FeaturedBooks.js ` and `npm run e2e -- --env firefox --test e2e_tests/tests/App/Collections.js ` to ensure the tests passes.

Note: Filter after click on one collection card action and filtering corresponds to: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/159