### PR TITLE
Remove duplicated recommended facet filter in sidebar menu

### DIFF
--- a/src/components/filters/Filters.vue
+++ b/src/components/filters/Filters.vue
@@ -17,7 +17,6 @@
       <publishers />
       <word-count />
       <h5-p-activities />
-      <recommended v-if="$store.state.stats.numberOfRecommendedBooksIndexed > 0" />
       <based-on />
       <storage-size />
     </v-list>


### PR DESCRIPTION
This change remove the duplicated "Recommended" facet filter in the side bar.