### PR TITLE
Remove filter applied by clicking the filter button 2nd time

### DIFF
--- a/e2e_tests/tests/CommonFilters/ExcludedFilters.js
+++ b/e2e_tests/tests/CommonFilters/ExcludedFilters.js
@@ -234,5 +234,49 @@ module.exports = {
           }
         });
       });
+  },
+  'Apply 2 subjects filters and then click in one filter twice to check if the 2nd filter was removed' (browser) {
+    browser
+      .url(process.env.HOST_TEST)
+      .waitForElementVisible('body')
+      .waitForElementVisible('#filter-about')
+      .click('#filter-about')
+      .pause(1000)
+      .click('*[data-test-include-btn="0"]')
+      .pause(1500)
+      .click('*[data-test-include-btn="1"]')
+      .pause(1500)
+      .click('*[data-test-include-btn="2"]')
+      .pause(1500)
+      .click('*[data-test-include-btn="1"]')
+      .pause(1500)
+      .getText('*[data-test-filter-item="1"]', (filterText) => {
+        filterText.value = filterText.value.split(' (')[0];
+        browser
+          .expect.element('*[data-test-chip-filters]')
+          .text.to.not.contain(filterText.value);
+      }).end();
+  },
+  'Exclude 2 subjects filters and then click in one filter twice to check if the 2nd filter was removed' (browser) {
+    browser
+      .url(process.env.HOST_TEST)
+      .waitForElementVisible('body')
+      .waitForElementVisible('#filter-about')
+      .click('#filter-about')
+      .pause(1000)
+      .click('*[data-test-exclude-btn="0"]')
+      .pause(1500)
+      .click('*[data-test-exclude-btn="1"]')
+      .pause(1500)
+      .click('*[data-test-exclude-btn="2"]')
+      .pause(1500)
+      .click('*[data-test-exclude-btn="1"]')
+      .pause(1500)
+      .getText('*[data-test-filter-item="1"]', (filterText) => {
+        filterText.value = filterText.value.split(' (')[0];
+        browser
+          .expect.element('*[data-test-chip-filters]')
+          .text.to.not.contain(filterText.value);
+      }).end();
   }
 };

--- a/src/components/filters/BasedOn.vue
+++ b/src/components/filters/BasedOn.vue
@@ -18,7 +18,6 @@
           <v-btn
             :id="'btn-include-based-another'"
             icon
-            :disabled="wasFiltered('true', false)"
             :class="wasFiltered('true', false) ? 'selected include': 'include'"
             @click="applyFilter(true, false)"
           >
@@ -29,7 +28,6 @@
           <v-btn
             :id="'btn-exclude-based-another'"
             icon
-            :disabled="wasFiltered('false', true)"
             :class="wasFiltered('false', true) ? 'selected exclude': 'exclude'"
             @click="applyFilter(true, true)"
           >
@@ -52,11 +50,19 @@ export default {
   },
   methods: {
     applyFilter(itemValue, exclude) {
+      if (this.wasFiltered((!exclude).toString(), exclude)) {
+        return this.removeFilter();
+      }
       let query = {...this.$route.query}, value;
       let attribute = this.$store.state.SClient.allowedFilters[this.field].alias;
       value = !exclude;
       query[attribute] = value;
       this.$router.replace({ query });
+    },
+    removeFilter() {
+      let queryString = {...this.$route.query};
+      delete queryString[this.$store.state.SClient.allowedFilters[this.field].alias];
+      this.$router.replace({ query: queryString });
     },
     wasFiltered(value, exc) {
       return typeof(this.$store.state.SClient.filtersExcluded['has_isBasedOn']) !== 'undefined' &&

--- a/src/components/filters/CurrentFilters.vue
+++ b/src/components/filters/CurrentFilters.vue
@@ -11,6 +11,7 @@
         <ul
           v-if="Object.keys($store.state.SClient.filtersExcluded).length > 0"
           class="ais-CurrentRefinements-list"
+          :data-test-chip-filters="Object.keys($store.state.SClient.filtersExcluded).length"
         >
           <li
             v-for="iv in $store.state.SClient.filtersExcluded"

--- a/src/styles/filters.scss
+++ b/src/styles/filters.scss
@@ -211,10 +211,12 @@
 
 .include.selected {
   background-color: $pb-blue;
+  color: white !important;
 }
 
 .exclude.selected {
   background-color: $pb-red;
+  color: white !important;
 }
 
 .theme--light.v-btn.v-btn--disabled.selected .v-icon, .theme--light.v-btn.v-btn--disabled .v-btn__loading{


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/95

This change does the following actions in ExcludeFilters 
and BasedOn components:
- Remove the `disable` html attribute in the filter buttons
(in the side filters menu) and implement 
- Add a new method for remove the filter applied.

Also, there is an small change in the styles for the filter buttons,
those were required to reflect the fact that the filter was applied
but the button is not disabled.

### How to test
- In the filters side menu, apply different filters by clicking 
buttons. You can combine "exclude" and "include" actions for 
different group of filters.
- Try to eliminate a single filter, by clicking in one of the 
buttons you clicked previously for filtering. The filter 
should be removed.
- Run new E2E tests: `npm run e2e --firefox --test e2e_tests/tests/CommonFilters/ExcludedFilters.js`