### PR TITLE
Convert empty values to 0 using computed properties before apply filter

### DIFF
--- a/e2e_tests/tests/NumericFilters/WordCount.js
+++ b/e2e_tests/tests/NumericFilters/WordCount.js
@@ -119,5 +119,21 @@ module.exports = {
               });
         }
       ).end();
-  }
+  },'Filtering books using only one filter with an empty value' (browser) {
+    browser
+      .url(process.env.HOST_TEST)
+      .waitForElementVisible('body')
+      .waitForElementVisible('#filter-wordCount')
+      .click('#filter-wordCount')
+      .waitForElementVisible('#max-wordCount')
+      .setValue('#max-wordCount', '') //an empty value will be converted to 0
+      .waitForElementVisible('#min-wordCount')
+      .setValue('#min-wordCount', '1')
+      .click('#btn-wordCount')
+      .pause(3000)
+      .elements('css selector', '.ais-CurrentRefinements-item', () => {
+        browser.expect.elements('.ais-CurrentRefinements-item .v-chip').count.to.equal(1);
+      })
+      .end();
+  },
 };

--- a/src/components/filters/commons/NumericFilters.vue
+++ b/src/components/filters/commons/NumericFilters.vue
@@ -15,7 +15,7 @@
               <v-col cols="4">
                 <v-text-field
                   :id="'min-' + field"
-                  v-model="number.min"
+                  v-model.trim.number="number.min"
                   type="number"
                   :min="0"
                   label="Min"
@@ -24,7 +24,7 @@
               <v-col cols="4">
                 <v-text-field
                   :id="'max-' + field"
-                  v-model="number.max"
+                  v-model.trim.number="number.max"
                   type="number"
                   :min="number.min"
                   label="Max"
@@ -86,6 +86,14 @@ export default {
       itemsFiltered: false
     };
   },
+  computed: {
+    min() {
+      return this.number.min.length === 0 ? 0 : this.number.min;
+    },
+    max() {
+      return this.number.max.length === 0 ? 0 : this.number.max;
+    }
+  },
   watch: {
     '$store.state.SClient.filtersExcluded': {
       deep: true,
@@ -127,8 +135,8 @@ export default {
     applyFilter() {
       let query = {...this.$route.query};
       let attribute = this.$store.state.SClient.allowedFilters[this.field].alias;
-      let min = parseInt(this.number.min);
-      let max = parseInt(this.number.max);
+      let min = parseInt(this.min);
+      let max = parseInt(this.max);
       if (min > max) {
         this.number.max = 0;
         query[attribute] = '>=' + min;


### PR DESCRIPTION
Related issue #160 

### Solution

* Convert empty values to 0 using computed properties before apply filter
* Added an extra validation for v-model trim and number modifiers

### How to test

1. Clear one of the numeric inputs (min or max) and press Go to apply the filter
2. The input should be converted to 0 transparent to the user and filter the result without issues

### E2E test

I added a test that only check if only one numeric filter is applied when the other is empty