### PR TITLE
Remove recommended filter applied by clicking the filter button twice.

### DIFF
--- a/e2e_tests/tests/MenuFilters/Recommended.js
+++ b/e2e_tests/tests/MenuFilters/Recommended.js
@@ -51,5 +51,28 @@ module.exports = {
       await browser.pause(3000);
       browser.expect.element('.ais-Hits__books__recommended').to.not.be.present;
     }
+  },
+  async 'Filtering by recommended books and removing filter by clicking the filter twice. Then exclude filter is applied' (browser) {
+    await browser
+      .url(process.env.HOST_TEST);
+    await browser
+      .waitForElementVisible('body');
+    await browser.pause(4000);
+    const isRecommendedVisible = await browser
+      .isVisible({
+        selector: '#filter-recommended',
+        index: 0,
+        suppressNotFoundErrors: true
+      });
+    if (parseInt(isRecommendedVisible.status) !== -1) {
+      await browser.click('#filter-recommended');
+      await browser.click('#btn-included-recommended');
+      await browser.pause(3000);
+      await browser.click('#btn-included-recommended');
+      await browser.pause(3000);
+      await browser.click('#btn-excluded-recommended');
+      await browser.pause(2000);
+      browser.expect.element('.ais-Hits__books__recommended').to.not.be.present;
+    }
   }
 };

--- a/src/components/filters/Recommended.vue
+++ b/src/components/filters/Recommended.vue
@@ -18,7 +18,6 @@
           <v-btn
             id="btn-included-recommended"
             icon
-            :disabled="wasFiltered('true', false)"
             :class="wasFiltered('true', false) ? 'selected include': 'include'"
             @click="applyFilter(true, false)"
           >
@@ -29,7 +28,6 @@
           <v-btn
             id="btn-excluded-recommended"
             icon
-            :disabled="wasFiltered('false', true)"
             :class="wasFiltered('false', true) ? 'selected exclude': 'exclude'"
             @click="applyFilter(true, true)"
           >
@@ -52,6 +50,9 @@ export default {
   },
   methods: {
     applyFilter(itemValue, exclude) {
+      if (this.wasFiltered((!exclude).toString(), exclude)) {
+        return this.removeFilter();
+      }
       let query = {...this.$route.query}, value;
       let attribute = this.$store.state.SClient.allowedFilters[this.field].alias;
       value = !exclude;
@@ -62,7 +63,12 @@ export default {
       return typeof(this.$store.state.SClient.filtersExcluded[this.field]) !== 'undefined' &&
           this.$store.state.SClient.filtersExcluded[this.field][0].value === value &&
           this.$store.state.SClient.filtersExcluded[this.field][0].exclude === is_excluded;
-    }
+    },
+    removeFilter() {
+      let queryString = {...this.$route.query};
+      delete queryString[this.$store.state.SClient.allowedFilters[this.field].alias];
+      this.$router.replace({ query: queryString });
+    },
   }
 };
 </script>


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/194

This change implements a new method in Recommended component, that remove the included/excluded filter applied by clicking in the button twice.
Also a E2E test related case was added.

### How to test
- Use the `dev_pressbooks_directory` index, which contains recommended books
- Apply **Recommended** facet filter in the sidebar menu by clicking the include / exclude button.
- After the filter was applied, click the same filter again, and the filter should be removed.