### PR TITLE
Perform the facet search right after the filter was applied

### DIFF
--- a/src/components/filters/commons/ExcludedFilters.vue
+++ b/src/components/filters/commons/ExcludedFilters.vue
@@ -168,12 +168,13 @@ export default {
               this.emptyFieldCount = filters[this.empty][i].count;
             }
           }
-          if (this.filterApplied && this.stringSearch.length > 0) {
-            this.searchForItems();
-          }
-          this.filterApplied = false;
           return true;
         }
+        if (this.filterApplied && this.stringSearch.length > 0) {
+          console.log(this.stringSearch);
+          this.searchForItems();
+        }
+        this.filterApplied = false;
       }
     },
     '$store.state.SClient.filtersExcluded': {


### PR DESCRIPTION
After this change: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/151
This issue happens: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/140
Only for those facets that doesn't contain `emtpy` filter.
This change, add the fix for the search in facet issue in any filter (with or without empty values allowed).

The reason because it was not captured in previous E2E tests, was because the data in dev was pretty small and we did not capture all the possible cases in this issue.