### PR TITLE
Remove hash in file assets name during building

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -12,5 +12,18 @@ module.exports = {
         return options;
       });
     }
+    if(config.plugins.has('extract-css')) {
+      const extractCSSPlugin = config.plugin('extract-css')
+      extractCSSPlugin && extractCSSPlugin.tap(() => [{
+        filename: '[name].css',
+        chunkFilename: '[name].css'
+      }]);
+    }
+  },
+  configureWebpack: {
+    output: {
+      filename: '[name].js',
+      chunkFilename: '[name].js'
+    }
   }
 };


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/161

This is a webpack configuration change to avoid hashes in files assets names.
It will allow us to build files with standard unhashed names names, following this structure:

```dist
├── app.css
├── app.js
├── app.js.map
├── assets
│   └── images
│       ├── algolia-logo.png
│       ├── default-book-cover.jpg
│       ├── h5p.png
│       ├── is-base.png
│       ├── is-child.png
│       ├── licenses
│       │   ├── 0.png
│       │   ├── allrights.png
│       │   ├── allrights-small.png
│       │   ├── by-nc-nd.png
│       │   ├── by-nc.png
│       │   ├── by-nc-sa.png
│       │   ├── by-nd.png
│       │   ├── by.png
│       │   ├── by-sa.png
│       │   └── public-domain.png
│       ├── no-image-available.png
│       └── pressbooks-logo.jpeg
├── chunk-vendors.css
├── chunk-vendors.js
├── chunk-vendors.js.map
├── favicon.png
├── index.html
└── robots.txt

```
Each build will use always the same file names and in this way we will have the same files name in our S3 Buckets after deployment.

This is the first step for implement S3 objects versioned, and in that way avoid multiple hashed deprecated files in the same bucket.
Also, we will can restore previous versions easily when needed.

### Test steps
- Run `npm run build` locally
- Make sure you have as a result a `dist` folder name
- The file structure should be the same displayed above.