### PR TITLE
Add all selectable filters in the side menu

### DIFF
--- a/src/components/filters/PbFilters.vue
+++ b/src/components/filters/PbFilters.vue
@@ -3,7 +3,7 @@
     <div class="font-semibold text-xl mb-8 md:mb-4">
       Filters:
     </div>
-    <vsa-list>
+    <vsa-list :auto-collapse="false">
       <pb-selectable-filters
         title="License"
         :searchable="false"


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/218

This PR add the remaining selectable filters. The selectable filters are:
- License
- Subject
- Network
- Language
- Publisher

This change does not include:
- the searchable feature
- filter items updated after a filter action. Which means, if you apply a filter, the rest of the available filters are not updated. (See: https://github.com/pressbooks/pressbooks-book-directory-fe/issues/222#issuecomment-825646880 for instance)

Those will be done in https://github.com/pressbooks/pressbooks-book-directory-fe/issues/222

### How to test
- Open a group of filter by clicking in the list title
- Apply different filters and make sure the filters are applied correctly. Implement multiple group of filters to make sure the combination works.
- Make sure you can open multiple filters list in the accordion.