### PR TITLE
Improve book cover styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@sentry/vue": "^6.2.5",
+        "@tailwindcss/aspect-ratio": "^0.2.0",
         "@tailwindcss/forms": "^0.3.2",
         "@tailwindcss/line-clamp": "^0.2.0",
         "@vue-hero-icons/outline": "^1.7.2",
@@ -2218,6 +2219,11 @@
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "peer": true
     },
+    "node_modules/@tailwindcss/aspect-ratio": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.0.tgz",
+      "integrity": "sha512-v5LyHkwXj/4lI74B06zUrmWEdmSqS43+jw717pkt3fAXqb7ALwu77A8t7j+Bej+ZbdlIIqNMYheGN7wSGV1A6w=="
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.3.2.tgz",
@@ -2609,8 +2615,6 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.2.tgz",
       "integrity": "sha512-W+2oVYeNghuBr3yTzZFQ5rfmjZtYB/Ubg87R5YOmlGrIb+Uw9f7qjUbhsj+/EkXhcV7eOD3jiM4+sgraX3FZUw==",
       "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -25068,6 +25072,11 @@
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "peer": true
     },
+    "@tailwindcss/aspect-ratio": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.0.tgz",
+      "integrity": "sha512-v5LyHkwXj/4lI74B06zUrmWEdmSqS43+jw717pkt3fAXqb7ALwu77A8t7j+Bej+ZbdlIIqNMYheGN7wSGV1A6w=="
+    },
     "@tailwindcss/forms": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.3.2.tgz",
@@ -25404,6 +25413,7 @@
       "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.5.12.tgz",
       "integrity": "sha512-8q67ORQ9O0Ms0nlqsXTVhaBefRBaLrzPxOewAZhdcO7onHwcO5/wRdWtHhZgfpCZlhY7NogkU16z3WnorSSkEA==",
       "requires": {
+        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -25416,15 +25426,15 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "https://registry.npmjs.org/core-js/-/core-js-3.10.2.tgz",
-          "integrity": "sha512-W+2oVYeNghuBr3yTzZFQ5rfmjZtYB/Ubg87R5YOmlGrIb+Uw9f7qjUbhsj+/EkXhcV7eOD3jiM4+sgraX3FZUw==",
-          "optional": true,
-          "peer": true
+          "version": "3.10.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.2.tgz",
+          "integrity": "sha512-W+2oVYeNghuBr3yTzZFQ5rfmjZtYB/Ubg87R5YOmlGrIb+Uw9f7qjUbhsj+/EkXhcV7eOD3jiM4+sgraX3FZUw=="
         },
         "semver": {
           "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@sentry/vue": "^6.2.5",
+    "@tailwindcss/aspect-ratio": "^0.2.0",
     "@tailwindcss/forms": "^0.3.2",
     "@tailwindcss/line-clamp": "^0.2.0",
     "@vue-hero-icons/outline": "^1.7.2",

--- a/src/components/collections/PbCollectionCard.vue
+++ b/src/components/collections/PbCollectionCard.vue
@@ -1,17 +1,18 @@
 <template>
-  <div class="item w-full mb-6 md:mb-0 md:w-1/5 px-3">
+  <div class="w-full h-full">
     <a
-      class="flex flex-col items-center"
-      @click="filter(card)"
+      href="#"
+      class="p-1 cursor-pointer h-full flex flex-col"
+      @click.prevent="filter(card)"
     >
-      <div class="image">
+      <div class="aspect-w-3 aspect-h-4 overflow-hidden">
         <img
           :src="card.image"
-          width="100%"
           :alt="card.name"
+          class="h-full w-full object-cover"
         >
       </div>
-      <div class="text py-4 px-2 font-semibold">
+      <div class="text mt-4 px-2 font-semibold">
         {{ truncateTitle(card.name) }}
       </div>
     </a>

--- a/src/components/collections/PbCollections.vue
+++ b/src/components/collections/PbCollections.vue
@@ -3,13 +3,13 @@
     class="bg-pb-blue"
     data-cy="collection-section"
   >
-    <div class="container mx-auto p-8">
+    <div class="container mx-auto py-10 px-8">
       <div class="border-gray-300">
         <div class="w-full mx-auto text-center">
           <h2 class="section-title font-bold text-4xl mb-12">
             Featured Collections
           </h2>
-          <div class="items flex flex-row flex-wrap items-center">
+          <div class="grid grid-cols-1 gap-y-3 md:grid-cols-5 md:gap-x-3">
             <pb-collection-card
               v-for="(card, n) in $store.state[storeName][storeProperty].slice(0, collectionCardsLimit)"
               :key="n"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ module.exports = {
     extend: {}
   },
   plugins: [
+    require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/line-clamp'),
     require('@tailwindcss/forms'),
   ],


### PR DESCRIPTION
This will close #270 

This PR improves the styling of book covers in featured collections to fix the aspect ratio for each cover.

#### How to test

* First it's required to run npm install (I added [this library](https://github.com/tailwindlabs/tailwindcss-aspect-ratio))
* Access the directory page and check if book covers are the same size
* Resize the page to check if covers behave properly in different breakpoints