### PR TITLE
Hide collections section when there is < 5 collections available

### DIFF
--- a/src/components/collections/PbCollections.vue
+++ b/src/components/collections/PbCollections.vue
@@ -1,5 +1,6 @@
 <template>
   <section
+    v-if="$store.state[storeName][storeProperty].length >= 5"
     class="bg-pb-blue"
     data-cy="collection-section"
   >


### PR DESCRIPTION
For those indexes that contains < 5 available collections, the *Collections* section is displayed anyway.
This change hide the collection section if the index does not provides >= 5 collections.