### PR TITLE
Add npm and node version required in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This Project is a Vue 3 vite project based on https://vitejs.dev/ is backwards c
 
 ### Requirements
 
-- Node.js version >=12.0.0.
+- Node.js version >=15.14.0.
+- NPM version >=7.0.0
 
 ### Install dependencies
 ```


### PR DESCRIPTION
Issue: https://app.zenhub.com/workspaces/pressbooks-product-backlog-2021-60ae7d807f6e370010b3d5be/issues/pressbooks/pressbooks-book-directory-fe/292

This PR add a small change in Readme.md file to specify the minimal version for node and npm.