### PR TITLE
New Algolia events and number format filter

### DIFF
--- a/e2e/fixtures/bookCard.json
+++ b/e2e/fixtures/bookCard.json
@@ -1,7 +1,7 @@
 {
   "network": "pressbooks.lib.vt.edu | Pressbooks at Virginia Tech",
   "title": "Significant Statistics",
-  "wordCount": "275135",
+  "wordCount": "275,135",
   "size": "233.53",
   "h5pActivities": "191",
   "authors": "Adapted by John Morgan Russell, from Barbara Illowsky and Susan Dean, David Diez, Mine Cetinkaya-Rundel and Christopher D. Barr, Julie Vu and David Harrington",

--- a/e2e/fixtures/selectableFilters.json
+++ b/e2e/fixtures/selectableFilters.json
@@ -123,7 +123,7 @@
         "Dini Afrika ya Mashariki",
         "Jinsia na Mapenzi Afrika ya Mashariki"
       ],
-      "count": 2182
+      "count": "2,182"
     }
   },
   "Collection": {

--- a/e2e/integration/filters/h5p.spec.js
+++ b/e2e/integration/filters/h5p.spec.js
@@ -1,6 +1,5 @@
 import {
   clickAccordionHeader,
-  encodeFacetFilterForURL,
   fillNumericValue,
   getNumericInput,
   submitNumericFilter
@@ -13,8 +12,7 @@ describe('H5p Count Filters',() => {
       clickAccordionHeader('h5pActivities');
     });
 
-    it('Filter is applied & URL is updated by entering MIN value',()=>{
-
+    it('Filter is applied & URL is updated by entering MIN value',() => {
       fillNumericValue('h5pActivities','min',100);
 
       submitNumericFilter('h5pActivities');
@@ -26,14 +24,11 @@ describe('H5p Count Filters',() => {
 
       cy.get(Elements.numberOfBooks)
         .contains( 'Results: 52');
-
     });
 
 
-    it('Filter is applied & URL is updated by entering MAX value',()=>{
-
-
-      fillNumericValue('h5pActivities','max',10);
+    it('Filter is applied & URL is updated by entering MAX value',() => {
+      fillNumericValue('h5pActivities', 'max', 10);
 
       submitNumericFilter('h5pActivities');
 
@@ -43,12 +38,10 @@ describe('H5p Count Filters',() => {
         .should('include','h5p=%3E%3D0%26%26%3C%3D10');
 
       cy.get(Elements.numberOfBooks)
-        .contains( 'Results: 2038');
-
+        .contains( 'Results: 2,038');
     });
 
-    it('Filter is applied & URL is updated by entering MIN and MAX values',()=>{
-
+    it('Filter is applied & URL is updated by entering MIN and MAX values',() => {
       fillNumericValue('h5pActivities','min',10);
 
       fillNumericValue('h5pActivities','max',20);
@@ -62,11 +55,9 @@ describe('H5p Count Filters',() => {
 
       cy.get(Elements.numberOfBooks)
         .contains( 'Results: 91');
-
     });
 
-    it('Filter chips is applied/removed when include/exclude filter is applied/removed',()=>{
-
+    it('Filter chips is applied/removed when include/exclude filter is applied/removed',() => {
       fillNumericValue('h5pActivities','min',10);
 
       fillNumericValue('h5pActivities','max',20);
@@ -88,12 +79,9 @@ describe('H5p Count Filters',() => {
       cy.algoliaQueryRequest('algoliaRequest');
 
       cy.get('[data-cy=chip-filter]').should('have.length', 0);
-
     });
 
-    it('Clicking a filter chip removes value from filter input and updates the URL',()=>{
-
-
+    it('Clicking a filter chip removes value from filter input and updates the URL',() => {
       fillNumericValue('h5pActivities','min',10);
 
       fillNumericValue('h5pActivities','max',20);
@@ -119,12 +107,9 @@ describe('H5p Count Filters',() => {
 
       cy.get(Elements.numberOfBooks)
         .contains( 'Results: 297');
-
     });
 
-    it('Make sure that min does not exceed max and max does not exceed min and no negative numbers are accepted',()=>{
-
-
+    it('Make sure that min does not exceed max and max does not exceed min and no negative numbers are accepted',() => {
       fillNumericValue('h5pActivities','min',-10);
 
       submitNumericFilter('h5pActivities');
@@ -158,8 +143,6 @@ describe('H5p Count Filters',() => {
         .should('include','h5p=%3E%3D100');
 
       getNumericInput('h5pActivities','max').invoke('text').should('eq','');
-
     });
-
   });
 });

--- a/e2e/integration/filters/wordCount.spec.js
+++ b/e2e/integration/filters/wordCount.spec.js
@@ -19,7 +19,7 @@ describe('Word Count Filters',() => {
         .should('include','words=%3E%3D1000');
 
       cy.get(Elements.numberOfBooks)
-        .contains( 'Results: 1734');
+        .contains( 'Results: 1,734');
 
     });
 
@@ -110,7 +110,7 @@ describe('Word Count Filters',() => {
         .should('not.include','20000');
 
       cy.get(Elements.numberOfBooks)
-        .contains( 'Results: 1734');
+        .contains( 'Results: 1,734');
 
     });
 

--- a/e2e/integration/headerStatCounts.spec.js
+++ b/e2e/integration/headerStatCounts.spec.js
@@ -10,13 +10,13 @@ describe('Welcome header book and network counts', () => {
 
     it('Shows the amount of books and networks indexed', function () {
       cy.get('@totalBooksIndexed').should('have.text', '2,329');
-      cy.get('@totalNetworksIndexed').should('have.text', 89);
+      cy.get('@totalNetworksIndexed').should('have.text', 96);
     });
 
     it('Does not change indexed amount after performing a search', function() {
       search('math science').then(() => {
         cy.get('@totalBooksIndexed').should('have.text', '2,329');
-        cy.get('@totalNetworksIndexed').should('have.text', 89);
+        cy.get('@totalNetworksIndexed').should('have.text', 96);
       });
     });
   });

--- a/e2e/integration/headerStatCounts.spec.js
+++ b/e2e/integration/headerStatCounts.spec.js
@@ -4,30 +4,19 @@ import Elements from '../support/elements';
 describe('Welcome header book and network counts', () => {
   context('Desktop resolution', () => {
     beforeEach(() => {
-
-      cy.get(Elements.search.input).as('inputSearch').clear();
-      cy.get(Elements.search.button).as('buttonSearch');
-
-      cy.wait('@fetching').then(({response}) => {
-
-        cy.wrap(response.body.nbHits).as('booksIndexed');
-        cy.wrap(Object.keys(response.body.facets.networkName).length).as('networksIndexed');
-
-      });
-
       cy.get('[data-cy=total-books-indexed]').as('totalBooksIndexed');
       cy.get('[data-cy=total-networks-indexed]').as('totalNetworksIndexed');
     });
 
     it('Shows the amount of books and networks indexed', function () {
-      cy.get('@totalBooksIndexed').should('have.text', this.booksIndexed);
-      cy.get('@totalNetworksIndexed').should('have.text', this.networksIndexed);
+      cy.get('@totalBooksIndexed').should('have.text', '2,329');
+      cy.get('@totalNetworksIndexed').should('have.text', 89);
     });
 
     it('Does not change indexed amount after performing a search', function() {
       search('math science').then(() => {
-        cy.get('@totalBooksIndexed').should('have.text', this.booksIndexed);
-        cy.get('@totalNetworksIndexed').should('have.text', this.networksIndexed);
+        cy.get('@totalBooksIndexed').should('have.text', '2,329');
+        cy.get('@totalNetworksIndexed').should('have.text', 89);
       });
     });
   });

--- a/src/components/PbStats.vue
+++ b/src/components/PbStats.vue
@@ -7,7 +7,7 @@
         class="font-semibold text-2xl mb-6"
         data-cy="number-of-books"
       >
-        Results:  {{ nbHits }} books
+        Results:  {{ nbHits | numberFormat }} books
       </div>
     </template>
   </ais-stats>

--- a/src/components/PbWelcomeHeader.vue
+++ b/src/components/PbWelcomeHeader.vue
@@ -9,7 +9,7 @@
       </h1>
 
       <p class="font-serif leading-7 text-lg">
-        This directory provides an index of <strong data-cy="total-books-indexed">{{ totalBooksIndexed }}</strong> books published across <strong data-cy="total-networks-indexed">{{ totalNetworksIndexed }}</strong> Pressbooks
+        This directory provides an index of <strong data-cy="total-books-indexed">{{ totalBooksIndexed | numberFormat }}</strong> books published across <strong data-cy="total-networks-indexed">{{ totalNetworksIndexed | numberFormat }}</strong> Pressbooks
         networks. Learn to use the Directory by taking a
         <button
           class="text-pb-red underline"

--- a/src/components/books/BookInfo.vue
+++ b/src/components/books/BookInfo.vue
@@ -20,7 +20,7 @@
       </a>
     </h2>
     <p class="leading-tight">
-      <span data-cy="book-word-count">{{ item.wordCount }}</span> words | <span data-cy="book-size">{{ sizeInMb }}</span> MB | <span data-cy="h5p-count">{{ item.h5pActivities }}</span> H5P activities
+      <span data-cy="book-word-count">{{ item.wordCount | numberFormat }}</span> words | <span data-cy="book-size">{{ sizeInMb }}</span> MB | <span data-cy="h5p-count">{{ item.h5pActivities | numberFormat }}</span> H5P activities
     </p>
   </div>
 </template>

--- a/src/components/dropdowns/PbPerPageDropdown.vue
+++ b/src/components/dropdowns/PbPerPageDropdown.vue
@@ -8,7 +8,7 @@
         placeholder="Books per page"
         :options="items"
         data-cy="books-per-page"
-        @input="(data)=>{
+        @input="(data) => {
           onInput(data)
         }"
       />
@@ -48,6 +48,10 @@ export default {
           data != routeQuery[this.alias]
         )
       ) {
+        this.sendFilterAppliedInsight(
+          [`value:${data}`],
+          'Per Page Changed'
+        );
         routeQuery[this.alias] = data;
         this.$router.replace({query: routeQuery});
       }

--- a/src/components/dropdowns/PbSortByDropdown.vue
+++ b/src/components/dropdowns/PbSortByDropdown.vue
@@ -50,6 +50,10 @@ export default {
           routeQuery[this.alias] != indexesOrderedByMap[data]
         )
       ) {
+        this.sendFilterAppliedInsight(
+          [`value:${data}`],
+          'Sort By Changed'
+        );
         routeQuery[this.alias] = indexesOrderedByMap[data];
         this.$router.replace({ query: routeQuery });
         refine(data);

--- a/src/components/forms/PbSearchBox.vue
+++ b/src/components/forms/PbSearchBox.vue
@@ -213,16 +213,32 @@ export default {
         scrollTo('#books');
         let query = {...this.$route.query};
         let attribute = this.$store.state.SClient.allowedFilters.search.alias;
-        query[attribute] = stringSearch;
-        if(this.$router.history.current.query.q !== query.q){
-          if (query.q !== '') {
-            this.sendFilterAppliedInsight(
-              [`search:${query.q}`],
-              'Search Applied'
-            );
-          }
-          this.$router.replace({ query });
+
+        if (query[attribute] === stringSearch) {
+          return;
         }
+
+        if (stringSearch === '') {
+          if (!query[attribute]) {
+            return;
+          }
+
+          delete query[attribute];
+
+          return this.$router.replace({query});
+        }
+
+        this.sendFilterAppliedInsight(
+          [`search:${stringSearch}`],
+          'Search Applied'
+        );
+
+        this.$router.replace({
+          query: {
+            ...query,
+            [attribute]: stringSearch
+          }
+        });
       }
     }
   }

--- a/src/components/forms/PbSearchBox.vue
+++ b/src/components/forms/PbSearchBox.vue
@@ -211,11 +211,16 @@ export default {
           stringSearch.length === 0 // Remove search case
       ) {
         scrollTo('#books');
-        NProgress.start();
         let query = {...this.$route.query};
         let attribute = this.$store.state.SClient.allowedFilters.search.alias;
         query[attribute] = stringSearch;
         if(this.$router.history.current.query.q !== query.q){
+          if (query.q !== '') {
+            this.sendFilterAppliedInsight(
+              [`search:${query.q}`],
+              'Search Applied'
+            );
+          }
           this.$router.replace({ query });
         }
       }

--- a/src/components/forms/PbShare.vue
+++ b/src/components/forms/PbShare.vue
@@ -102,6 +102,10 @@ export default {
       this.isCopied = false;
     },
     copyToClipboard() {
+      this.sendFilterAppliedInsight(
+        [`url:${this.currentUrl}`],
+        'Share This Query'
+      );
       navigator.clipboard.writeText(this.currentUrl).then(()=> {
         this.isCopied = true;
         setTimeout(()=>{

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import router from './router';
 import VueTailwindConfig from './vuetailwind.config';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import AlgoliaMixin from './mixins/AlgoliaMixin.vue';
+import AlgoliaMixin from './mixins/AlgoliaMixin';
 import './index.css';
 import {store} from './store';
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ Vue.component('VueSelect', VueSelect);
 Vue.use(InstantSearch);
 Vue.use(VueTailwind, VueTailwindConfig);
 Vue.mixin(AlgoliaMixin);
+Vue.filter('numberFormat', (value, locale) => value.toLocaleString(locale || 'en'));
 
 dayjs.extend(utc);
 

--- a/src/mixins/AlgoliaMixin.js
+++ b/src/mixins/AlgoliaMixin.js
@@ -1,4 +1,3 @@
-<script>
 import searchInsights from 'search-insights';
 
 export default {
@@ -32,5 +31,3 @@ export default {
     },
   }
 };
-</script>
-


### PR DESCRIPTION
Issues #374 and #317

This PR adds new Algolia insight events

* Search action with query/term used
* Share this query event
* Change sort by
* Change per page

It also applies number formatting to include a comma for thousands place. 

### How to test

1. Apply a search term on the directory
1. Copy the URL from the Share this query dialog
1. Change the per page and sorting options
1. Open the Algolia dashboard for your application and go to "Monitoring" option on the sidebar
![Screen Shot 2021-06-28 at 13 47 57](https://user-images.githubusercontent.com/1761690/123674032-87418e80-d817-11eb-81a0-0c8111273ad1.png)
1. Click on the "Insight API Logs" option. You should see a list similar to this:
![Screen Shot 2021-06-28 at 13 49 02](https://user-images.githubusercontent.com/1761690/123674183-b22be280-d817-11eb-8b1b-0e4cd77109bf.png)
1. Ensure that events are being sent properly (name, type, index, etc.)
1. Ensure that thousands include a comma