### PR TITLE
Fix variable reference so that robots.txt gets removed from production directory

### DIFF
--- a/src/utils/cleanup.js
+++ b/src/utils/cleanup.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 export default {
   name: 'cleanup',
   generateBundle() {
-    if( process.env.NODE_ENV === 'production' )
+    if( process.env.VITE_USER_NODE_ENV === 'production' )
       fs.unlinkSync('./dist/robots.txt');
   }
 };


### PR DESCRIPTION
V2 of the Directory changed several env variable names, including NODE_ENV (now VITE_USER_NODE_ENV). This PR fixes the variable name so that robots.txt will be successfully removed from the production version of the Directory. Partial fix for https://github.com/pressbooks/pressbooks-book-directory-fe/issues/385. Not sure how best to test this ...
 