### PR TITLE
Improved cleanup plugin

### DIFF
--- a/src/utils/cleanup.js
+++ b/src/utils/cleanup.js
@@ -1,8 +1,11 @@
 import fs from 'fs';
-export default {
+
+const cleanup = ()=>({
   name: 'cleanup',
-  generateBundle() {
+  buildStart() {
     if( process.env.NODE_ENV === 'production' )
-      fs.unlinkSync('./dist/robots.txt');
+      fs.unlinkSync('public/robots.txt');
   }
-};
+});
+
+export default cleanup;

--- a/src/utils/cleanup.js
+++ b/src/utils/cleanup.js
@@ -2,9 +2,9 @@ import fs from 'fs';
 
 const cleanup = ()=>({
   name: 'cleanup',
-  buildStart() {
+  generateBundle() {
     if( process.env.NODE_ENV === 'production' )
-      fs.unlinkSync('public/robots.txt');
+      fs.unlinkSync('dist/robots.txt');
   }
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import { injectHtml } from 'vite-plugin-html';
 import cleanup from './src/utils/cleanup';
 
 module.exports = {
-  plugins: [createVuePlugin(/*options*/),injectHtml(), cleanup],
+  plugins: [createVuePlugin(/*options*/),injectHtml(), cleanup()],
   server: {
     port: 3001
   },


### PR DESCRIPTION
I improved the cleanup function to remove the robots.txt file before the build instead of after the build

# How to test

1. Run npm run build
2. The robots.txt should not be present on the dist directory
3. Run npm run build:staging
4. The robots.txt should be present in dist/ directory