### PR TITLE
Restore link to H5P listing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6174,7 +6174,6 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
@@ -22606,6 +22605,7 @@
       "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.5.13.tgz",
       "integrity": "sha512-pM7CR3yXB6L8Gfn6EmX7FLNE3+V/15I3o33GkSNsWvgsMp6HVGXKkXgojrcfUUauyL1LZOdvTmu4enU2RePGHw==",
       "requires": {
+        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -22618,6 +22618,7 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }
@@ -25843,8 +25844,7 @@
     "core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "devOptional": true
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-js-compat": {
       "version": "3.12.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:staging": "TAILWIND_MODE=build vite build --mode staging",
     "serve": "vite preview",
     "lint": "eslint ./src --ext .js --ext .vue",
+    "lint:fix": "eslint ./src --ext .js --ext .vue --fix",
     "start": "npm run dev & wait-on tcp:3001 -v",
     "test": "cypress open",
     "test:ci": "cypress run --headless",

--- a/src/components/books/BookInfo.vue
+++ b/src/components/books/BookInfo.vue
@@ -20,7 +20,18 @@
       </a>
     </h2>
     <p class="leading-tight">
-      <span data-cy="book-word-count">{{ item.wordCount | numberFormat }}</span> words | <span data-cy="book-size">{{ sizeInMb }}</span> MB | <span data-cy="h5p-count">{{ item.h5pActivities | numberFormat }}</span> H5P activities
+      <span data-cy="book-word-count">{{ item.wordCount | numberFormat }}</span> words | <span data-cy="book-size">{{ sizeInMb }}</span> MB | <template v-if="hasH5PActivities">
+        <a
+          :href="item.url + 'h5p-listing'"
+          class="text-pb-red underline"
+          target="_blank"
+        ><span data-cy="h5p-count">{{ item.h5pActivities | numberFormat }}</span> H5P activities</a>
+      </template>
+      <template v-else>
+        <span
+          data-cy="h5p-count"
+        >{{ item.h5pActivities | numberFormat }}</span> H5P activities
+      </template>
     </p>
   </div>
 </template>
@@ -40,6 +51,9 @@ export default {
       const size = (parseInt(this.item.storageSize) / 1024) / 1024;
 
       return size.toFixed(2);
+    },
+    hasH5PActivities() {
+      return this.item.hasH5pActivities && this.item.h5pActivities > 0;
     }
   },
   methods: {


### PR DESCRIPTION
This PR adds a link to the '# H5P Activities' text for all book cards which have 1 H5P activities which points to the book's improved H5P listing page. This feature was removed in a previous Directory release because the H5P listing page was unstable and can now be restored.

## To Test
1. Checkout this branch
2. Observe that books with no H5P activities display '0 H5P activities' with no link
3. Observe that books with 1 or more H5P activitise display the number of H5P activities with a link that open the book's h5p listing page in a new tab
![Screenshot from 2021-08-03 15-48-09](https://user-images.githubusercontent.com/13485451/128096049-478df0d1-ca11-460f-b208-0bbc82ef56b3.png)
