### PR TITLE
Add anchor to the book cover

### DIFF
--- a/e2e/integration/bookCards.spec.js
+++ b/e2e/integration/bookCards.spec.js
@@ -200,7 +200,7 @@ describe('Book cards', function () {
       cy.get(Elements.booksCards.cover)
         .eq(2).find('img')
         .should('have.attr', 'src')
-        .should('include', 'monarch.jpg');
+        .should('include', 'TPM-cover-third-edition.png');
     });
   });
 });

--- a/src/components/PbBookCover.vue
+++ b/src/components/PbBookCover.vue
@@ -1,12 +1,17 @@
 <template>
-  <div
+  <a
     v-lazy-container="{ selector: 'img', error: defaulImg, loading: defaulImg }"
+    :href="url"
+    target="_blank"
+    rel="noopener"
+    data-cy="book-cover"
+    @click="$emit('book-cover-click')"
   >
     <img
       class="w-full"
       :data-src="image"
     >
-  </div>
+  </a>
 </template>
 
 <script>
@@ -18,7 +23,12 @@ export default {
       type: String,
       default: ''
     },
+    url: {
+      type: String,
+      default: ''
+    }
   },
+  emits: ['book-cover-click'],
   data() {
     return {
       defaulImg: '/assets/images/default-book-cover.jpg'

--- a/src/components/books/BookCard.vue
+++ b/src/components/books/BookCard.vue
@@ -23,7 +23,10 @@
       />
       <book-details :item="item" />
     </div>
-    <book-media :item="item" />
+    <book-media
+      :item="item"
+      @book-title-click="$emit('book-clicked')"
+    />
   </article>
 </template>
 <script>

--- a/src/components/books/BookInfo.vue
+++ b/src/components/books/BookInfo.vue
@@ -14,7 +14,7 @@
         target="_blank"
         rel="noopener"
         data-cy="book-title"
-        @click="clickBook"
+        @click="$emit('book-title-click')"
       >
         {{ item.name }}
       </a>
@@ -45,7 +45,7 @@ export default {
       default() { return {}; }
     },
   },
-  emits: ['title-clicked'],
+  emits: ['book-title-click'],
   computed: {
     sizeInMb() {
       const size = (parseInt(this.item.storageSize) / 1024) / 1024;
@@ -54,22 +54,6 @@ export default {
     },
     hasH5PActivities() {
       return this.item.hasH5pActivities && this.item.h5pActivities > 0;
-    }
-  },
-  methods: {
-    clickBook() {
-      this.$emit('book-title-click');
-      const clickEndpoint = import.meta.env.VITE_CLICK_COUNT_ENDPOINT;
-      if (clickEndpoint) {
-        fetch(clickEndpoint,{
-          mode: 'no-cors',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({book_id:this.item.objectID}),
-        });
-      }
     }
   }
 };

--- a/src/components/books/BookMedia.vue
+++ b/src/components/books/BookMedia.vue
@@ -6,7 +6,9 @@
     >
       <pb-book-cover
         :image="item.image"
+        :url="item.url"
         :alt="`${item.name} cover`"
+        @book-cover-click="$emit('book-title-click')"
       />
     </div>
     <ul
@@ -55,6 +57,7 @@ export default {
       default() { return {}; }
     },
   },
+  emits: ['book-title-click'],
   computed: {
     hasH5PActivities() {
       return this.item.hasH5pActivities && this.item.h5pActivities > 0;

--- a/src/components/books/Books.vue
+++ b/src/components/books/Books.vue
@@ -15,7 +15,7 @@
         v-for="item in items"
         :key="item.objectID"
         :item="item"
-        @book-clicked="sendEvent('conversion', item, 'Book Opened')"
+        @book-clicked="handleBookClicked(item, sendEvent)"
       />
     </template>
   </ais-hits>
@@ -70,6 +70,22 @@ export default {
         return this.removeXMLTags(helpers.functions.unescapeHTML(item.disambiguatingDescription));
       }
       return item.hasDescription ? this.removeXMLTags(helpers.functions.unescapeHTML(item.description)) : '';
+    },
+    handleBookClicked(item, sendEvent) {
+      sendEvent('conversion', item, 'Book Opened');
+ 
+      const clickEndpoint = import.meta.env.VITE_CLICK_COUNT_ENDPOINT;
+
+      if (clickEndpoint) {
+        fetch(clickEndpoint,{
+          mode: 'no-cors',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({book_id: item.objectID}),
+        });
+      }
     }
   }
 };


### PR DESCRIPTION
Issue #407 

This PR adds an anchor to the book cover image, which behaves the same way as clicking on the book title.

### How to test

1. Using this branch, open the directory locally
2. Check that cover images render properly and are wrapped in an anchor tag
3. Clicking the cover image should have the same effect as if you were clicking the book title
4. Make sure that clicking the book title/book cover triggers algolia event and the visit to increment click count