### PR TITLE
Node specific version on buildspec

### DIFF
--- a/buildspec_dev.yml
+++ b/buildspec_dev.yml
@@ -4,7 +4,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 14.x
+      nodejs: 14
     commands:
       - node -v
       - npm -v


### PR DESCRIPTION
The build failed with: Phase context status code: YAML_FILE_ERROR Message: Major version of alias '14.x' is not supported in runtime 'nodejs'.

It seems contradictory with the DOCS `https://docs.aws.amazon.com/codebuild/latest/userguide/runtime-versions.html`