### PR TITLE
fix: check if has editors before trying to render them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pressbooks-directory",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10479,9 +10479,9 @@
           }
         },
         "tailwindcss": {
-          "version": "npm:@tailwindcss/postcss7-compat@2.2.16",
-          "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.16.tgz",
-          "integrity": "sha512-k+f6DL1KxG0d2dEUILxytWpHRBPMagQ8wUdH5bJUzbmv7TPd3yriR+nSOXy2Hcvt79cP3Lgc5J6oPjO4PNyRLg==",
+          "version": "npm:@tailwindcss/postcss7-compat@2.2.17",
+          "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.17.tgz",
+          "integrity": "sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==",
           "requires": {
             "arg": "^5.0.1",
             "autoprefixer": "^9",

--- a/src/components/books/BookDetails.vue
+++ b/src/components/books/BookDetails.vue
@@ -11,7 +11,7 @@
         data-cy="book-authors"
       />
       <meta-info
-        v-if="item.hasEditor"
+        v-if="hasEditor"
         title="Editor(s): "
         :text="editors"
         data-cy="book-editors"
@@ -104,6 +104,9 @@ export default {
     },
     hasSubjects() {
       return this.item.about && this.item.about.length > 0;
+    },
+    hasEditor(){
+      return this.item.editor && this.item.editor.length > 0;
     },
     authors() {
       return this.item.author.join(', ');


### PR DESCRIPTION
This PR fixes book cards not being rendered properly when some fields are empty or missing.

### Test

1. On the dev branch
2. Change the .env file  to use Algolia's dev indexes where we have some missing data
3. Notice that book cards will not render properly
4. Checkout this branch and make sure the cards are now rendering properly