### PR TITLE
431 clear filters curated collections

### DIFF
--- a/e2e/integration/filters/clearFiltersForCuratedCollections.spec.js
+++ b/e2e/integration/filters/clearFiltersForCuratedCollections.spec.js
@@ -1,0 +1,84 @@
+import {
+  clickAccordionHeader,
+  clickFilter,
+} from '../../support/common';
+
+describe('Clear Filters When Click On a Curated Collection',() => {
+  context('Desktop Resolution', () => {
+    beforeEach(() => {
+
+      cy.get("[data-cy=active-filters]").then($activeFilter => {
+        if ($activeFilter.find("[data-cy=clear-all-filters]").length > 0) {
+          cy.get('[data-cy=clear-all-filters]').click();
+          cy.algoliaQueryRequest('algoliaRequest');
+         
+        }
+      });
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 0);
+
+      cy.algoliaQueryRequest('algoliaRequest');
+
+    });
+
+    it('Add some filters and then click on one curated collection', () => {
+
+      clickAccordionHeader('licenseCode');
+      clickFilter('licenseCode','cc-by', 'include');
+      clickFilter('licenseCode','cc-by-nc-sa', 'include');
+      clickFilter('licenseCode','all-rights-reserved', 'include');
+      
+      cy.get('[data-cy=chip-filter]').should('have.length', 3);
+
+      cy.algoliaQueryRequest('algoliaRequest');
+
+      cy.get('[data-cy=collection-section] li').first().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+
+      cy.algoliaQueryRequest('algoliaRequest');
+      
+    });
+
+    it('Click on more than one curated collection', () => {
+
+      cy.get('[data-cy=collection-section] li').first().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+      
+      cy.algoliaQueryRequest('algoliaRequest');
+
+      cy.get('[data-cy=collection-section] li').last().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+      
+      cy.algoliaQueryRequest('algoliaRequest');
+
+    });
+
+    it('Click on a collection then add some filters', () => {
+      
+      cy.get('[data-cy=collection-section] li').first().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+      
+      cy.algoliaQueryRequest('algoliaRequest');
+
+      clickAccordionHeader('licenseCode');
+      clickFilter('licenseCode','cc-by', 'include');
+      clickFilter('licenseCode','cc-by-nc-sa', 'include');
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 3);
+
+      cy.algoliaQueryRequest('algoliaRequest');
+
+      cy.get('[data-cy=collection-section] li').last().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+      
+      cy.algoliaQueryRequest('algoliaRequest');
+
+    });
+    
+  });
+});

--- a/e2e/integration/filters/clearFiltersForCuratedCollections.spec.js
+++ b/e2e/integration/filters/clearFiltersForCuratedCollections.spec.js
@@ -9,8 +9,8 @@ describe('Clear Filters When Click On a Curated Collection',() => {
   context('Desktop Resolution', () => {
     beforeEach(() => {
 
-      cy.get("[data-cy=active-filters]").then($activeFilter => {
-        if ($activeFilter.find("[data-cy=clear-all-filters]").length > 0) {
+      cy.get('[data-cy=active-filters]').then($activeFilter => {
+        if ($activeFilter.find('[data-cy=clear-all-filters]').length > 0) {
           cy.get('[data-cy=clear-all-filters]').click();
           cy.algoliaQueryRequest('algoliaRequest');
          
@@ -82,7 +82,7 @@ describe('Clear Filters When Click On a Curated Collection',() => {
 
     });
 
-    it.only('Make a query search and then click on a curated collenction', () => {
+    it('Make a query search and then click on a curated collenction', () => {
 
       cy.get(Elements.search.input).as('inputSearch').clear();
       cy.get(Elements.search.button).as('buttonSearch');
@@ -90,7 +90,7 @@ describe('Clear Filters When Click On a Curated Collection',() => {
       search('math');
 
       cy.url()
-      .should('include','q=math');
+        .should('include','q=math');
 
       cy.get('[data-cy=book-card]').its('length').should('be.gte', 0);
 

--- a/e2e/integration/filters/clearFiltersForCuratedCollections.spec.js
+++ b/e2e/integration/filters/clearFiltersForCuratedCollections.spec.js
@@ -2,6 +2,8 @@ import {
   clickAccordionHeader,
   clickFilter,
 } from '../../support/common';
+import {search} from '../../support/common';
+import Elements from '../../support/elements';
 
 describe('Clear Filters When Click On a Curated Collection',() => {
   context('Desktop Resolution', () => {
@@ -79,6 +81,38 @@ describe('Clear Filters When Click On a Curated Collection',() => {
       cy.algoliaQueryRequest('algoliaRequest');
 
     });
-    
+
+    it.only('Make a query search and then click on a curated collenction', () => {
+
+      cy.get(Elements.search.input).as('inputSearch').clear();
+      cy.get(Elements.search.button).as('buttonSearch');
+
+      search('math');
+
+      cy.url()
+      .should('include','q=math');
+
+      cy.get('[data-cy=book-card]').its('length').should('be.gte', 0);
+
+      cy.get('[data-cy=collection-section] li').first().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+      
+      cy.algoliaQueryRequest('algoliaRequest');
+
+      cy.get(Elements.search.input).invoke('val').should('be.empty');
+
+      search('math');
+
+      cy.get('[data-cy=collection-section] li').last().click();
+
+      cy.get('[data-cy=chip-filter]').should('have.length', 1);
+      
+      cy.algoliaQueryRequest('algoliaRequest');
+
+      cy.get(Elements.search.input).invoke('val').should('be.empty');
+
+    });
+
   });
 });

--- a/e2e/integration/filters/lastUpdated.spec.js
+++ b/e2e/integration/filters/lastUpdated.spec.js
@@ -170,7 +170,7 @@ describe('Filter last updated', () => {
         .should('contain.text', '04-1-2021');
     });
 
-    it.only('Removing chip will remove the date filter', () => {
+    it('Removing chip will remove the date filter', () => {
       cy.visit('/?sort=updated&updated=%3C%3D1619567999');
 
       cy.get('@toLastUpdated').should('contain.value', 'April 27, 2021');

--- a/e2e/support/common.js
+++ b/e2e/support/common.js
@@ -143,7 +143,8 @@ function sortBy(textIndex) {
     .get('[data-cy=sort-books-by]')
     .find('.vs__dropdown-option')
     .contains(textIndex)
-    .click();
+    .click()
+    .wait(1000);
 }
 
 function perPage(amount) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10479,7 +10479,7 @@
           }
         },
         "tailwindcss": {
-          "version": "npm:tailwindcss@2.2.17",
+          "version": "npm:@tailwindcss/postcss7-compat@2.2.17",
           "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.17.tgz",
           "integrity": "sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==",
           "requires": {

--- a/src/components/collections/PbCollectionCard.vue
+++ b/src/components/collections/PbCollectionCard.vue
@@ -64,7 +64,6 @@ export default {
       this.sendClickInsight();
       this.$router.replace({
         query: {
-          ...query,
           [this.alias]: this.card.name
         }
       });

--- a/src/components/collections/PbCollectionCard.vue
+++ b/src/components/collections/PbCollectionCard.vue
@@ -55,16 +55,22 @@ export default {
     filter() {
       let query = {...this.$route.query};
 
-      if (query[this.alias] === this.card.name) {
+      scrollTo('#books');
+
+      const keysAmount = ('per_page' in query) ? 2 : 1;
+
+      if (query[this.alias] === this.card.name && Object.entries(query).length ===keysAmount) {
         return;
       }
-
-      scrollTo('#books');
+      
+      const { per_page } = this.$route.query;
 
       this.sendClickInsight();
       this.$router.replace({
         query: {
-          [this.alias]: this.card.name
+          [this.alias]: this.card.name,
+          per_page,
+          q:[]
         }
       });
     },

--- a/src/store/modules/stats.js
+++ b/src/store/modules/stats.js
@@ -52,7 +52,7 @@ export default {
     setFilters(state, response) {
       let filters = Object.keys(response.facets).reduce((filters, facetName) => {
         if (state.keepFacets.includes(facetName)) {
-          filters[facetName] = [...state.filters[facetName]];
+          filters[facetName] = [...state.filters[facetName] || []];
 
           return filters;
         }


### PR DESCRIPTION
This PR fixes #431, Filters must be cleared when users click on a card of the Curated Collection section.-

**To Test:**

- On the dev branch
- Apply some filters and then click on one card from the Curated Collection section
- Notice the previous filters are still applied
- Check out this branch and make sure the filters are cleared before applying the card's filter.-
- Also notice you have clearFiltersForCuratedCollections.spec that covers the most common uses of this feature