### PR TITLE
fix: pin working version of search-insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "intro.js": "6.0.0",
         "nprogress": "^0.2.0",
         "resize-detector": "^0.3.0",
-        "search-insights": "2.6.0",
+        "search-insights": "2.5.0",
         "vue": "^3.2.37",
         "vue-instantsearch": "^4.9.0",
         "vue-lazyload": "^3.0.0",
@@ -7810,6 +7810,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/instantsearch.js/node_modules/search-insights": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.6.0.tgz",
+      "integrity": "sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==",
+      "engines": {
+        "node": ">=8.16.0"
+      }
+    },
     "node_modules/intro.js": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/intro.js/-/intro.js-6.0.0.tgz",
@@ -11214,9 +11222,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.6.0.tgz",
-      "integrity": "sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.5.0.tgz",
+      "integrity": "sha512-TbWuOTfG7/JMemNF4D8V0clQy49287Ql/kQ8q+byhVywpdHSsx2PMLzSawIxDm87jUb98w2qR7H1V4koqqt83w==",
       "engines": {
         "node": ">=8.16.0"
       }
@@ -19127,6 +19135,11 @@
           "version": "6.9.7",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
           "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+        },
+        "search-insights": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.6.0.tgz",
+          "integrity": "sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw=="
         }
       }
     },
@@ -21569,9 +21582,9 @@
       }
     },
     "search-insights": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.6.0.tgz",
-      "integrity": "sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.5.0.tgz",
+      "integrity": "sha512-TbWuOTfG7/JMemNF4D8V0clQy49287Ql/kQ8q+byhVywpdHSsx2PMLzSawIxDm87jUb98w2qR7H1V4koqqt83w=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "intro.js": "6.0.0",
     "nprogress": "^0.2.0",
     "resize-detector": "^0.3.0",
-    "search-insights": "2.6.0",
+    "search-insights": "2.5.0",
     "vue": "^3.2.37",
     "vue-instantsearch": "^4.9.0",
     "vue-lazyload": "^3.0.0",


### PR DESCRIPTION
Version 2.6.0 of search insights breaks our search and filtering features. This PR reverts that dependency until https://github.com/pressbooks/pressbooks-book-directory-fe/issues/826 is addressed.