### PR TITLE
feat: add Institution filter and display institutions on book card

### DIFF
--- a/e2e/fixtures/bookCard.json
+++ b/e2e/fixtures/bookCard.json
@@ -7,6 +7,7 @@
   "editors": "Anita Walz",
   "subjects": "Probability and statistics",
   "lastUpdated": "04-27-2021",
+  "institutions": "Virginia Polytechnic Institute and State University",
   "publisher": "Department of Statistics in affiliation with the University Libraries at Virginia Tech",
   "language": "English",
   "description": "Significant Statistics: An Introduction to Statistics is intended for the one-semester",

--- a/e2e/fixtures/selectableFilters.json
+++ b/e2e/fixtures/selectableFilters.json
@@ -99,6 +99,16 @@
       "count": 89
     }
   },
+  "Institution": {
+    "includes": [ "University of Wisconsin-Madison", "Queens College" ],
+    "excludes": [ "University of Oregon", "University of Newcastle" ],
+    "field": "institutionName",
+    "urlAlias": "inst",
+    "search": {
+      "searchTerm": "Oreg",
+      "filter": "University of Oregon"
+    }
+},
   "Publisher": {
     "includes": [ "Rebus Community", "The Ohio State University" ],
     "excludes": [ "BCcampus", "OpenStax" ],

--- a/e2e/fixtures/selectableFilters.json
+++ b/e2e/fixtures/selectableFilters.json
@@ -102,7 +102,7 @@
   "Institution": {
     "includes": [ "University of Wisconsin-Madison", "Queens College" ],
     "excludes": [ "University of Oregon", "University of Newcastle" ],
-    "field": "institutionName",
+    "field": "institutions",
     "urlAlias": "inst",
     "search": {
       "searchTerm": "Oreg",

--- a/e2e/fixtures/selectableFilters.json
+++ b/e2e/fixtures/selectableFilters.json
@@ -107,6 +107,15 @@
     "search": {
       "searchTerm": "Oreg",
       "filter": "University of Oregon"
+    },
+    "bookCards": {
+      "filters": [ "University of Oregon" ],
+      "include": true,
+      "titles": [
+        "Example Webinar Book",
+        "Prior Learning Portfolio Development"
+      ],
+      "count": 2
     }
 },
   "Publisher": {

--- a/e2e/integration/bookCards.cy.js
+++ b/e2e/integration/bookCards.cy.js
@@ -54,7 +54,7 @@ describe('Book cards', function () {
         });
     });
     it('Filter by institution and check the institution attribute is present in the book cards', () => {
-      const institutionFilter = 'University of Wisconsin-Madison', facet = 'institutionName';
+      const institutionFilter = 'University of Wisconsin-Madison', facet = 'institutions';
       clickAccordionHeader(facet);
       clickFilter(facet, institutionFilter, true);
       cy.get(Elements.bookCards.institutions)

--- a/e2e/integration/bookCards.cy.js
+++ b/e2e/integration/bookCards.cy.js
@@ -91,7 +91,7 @@ describe('Book cards', function () {
         .first()
         .should('include.text','Written specifically for students in Boise State University’s Bachelor of Applied Science');
     });
-    it('Check all book cards attributes from a particular book', () => {
+    it('Check all book card attributes from a particular book', () => {
       const attributesToCheck =  [
         {
           element: Elements.bookCards.network,

--- a/e2e/integration/bookCards.cy.js
+++ b/e2e/integration/bookCards.cy.js
@@ -53,6 +53,17 @@ describe('Book cards', function () {
             .contains(publisherFilter);
         });
     });
+    it('Filter by institution and check the institution attribute is present in the book cards', () => {
+      const institutionFilter = 'University of Wisconsin-Madison', facet = 'institutionName';
+      clickAccordionHeader(facet);
+      clickFilter(facet, institutionFilter, true);
+      cy.get(Elements.bookCards.institutions)
+        .each(($institutionElement) => {
+          cy.wrap($institutionElement)
+            .should('exist')
+            .contains(institutionFilter);
+        });
+    });
     it('Filter by license and check that the license description is present in the book cards', () => {
       const licenseFilter = {
         name: 'CC BY-NC',
@@ -122,6 +133,10 @@ describe('Book cards', function () {
         {
           element: Elements.bookCards.editors,
           fixtureProperty: 'editors'
+        },
+        {
+          element: Elements.bookCards.institutions,
+          fixtureProperty: 'institutions'
         },
         {
           element: Elements.bookCards.publisher,

--- a/e2e/support/elements.js
+++ b/e2e/support/elements.js
@@ -18,6 +18,7 @@ const Elements = {
     license: '[data-cy=book-copyright-license]',
     subjects: '[data-cy=book-subjects]',
     description: '[data-cy=book-description]',
+    institutions: '[data-cy=book-institutions]',
     publisher: '[data-cy=book-publisher]',
     original: '[data-cy=book-original]',
     notOriginal: '[data-cy=book-not-original]',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pressbooks-directory",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pressbooks-directory",
-      "version": "2.7.1",
+      "version": "2.8.0",
       "dependencies": {
         "@heroicons/vue": "^2.0.18",
         "@tailwindcss/aspect-ratio": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pressbooks-directory",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "type": "module",
   "engines": {
     "node": ">=16.0.0"

--- a/src/components/books/BookDetails.vue
+++ b/src/components/books/BookDetails.vue
@@ -106,7 +106,7 @@ export default {
       return this.item.hasLastUpdated;
     },
     hasInstitutions() {
-      return this.item.institutions && this.item.author.length > 0;
+      return this.item.institutions && this.item.institutions.length > 0;
     },
     hasPublisher() {
       return this.item.publisherName;

--- a/src/components/books/BookDetails.vue
+++ b/src/components/books/BookDetails.vue
@@ -29,6 +29,12 @@
         :text="lastUpdated"
       />
       <meta-info
+        v-if="hasInstitutions"
+        title="Institution(s): "
+        :text="institutions"
+        data-cy="book-institutions"
+      />
+      <meta-info
         v-if="hasPublisher"
         title="Publisher: "
         :text="item.publisherName"
@@ -99,6 +105,9 @@ export default {
     hasLastUpdated() {
       return this.item.hasLastUpdated;
     },
+    hasInstitutions() {
+      return this.item.institutions && this.item.author.length > 0;
+    },
     hasPublisher() {
       return this.item.publisherName;
     },
@@ -113,6 +122,9 @@ export default {
     },
     subjects() {
       return this.item.about.join(', ');
+    },
+    institutions() {
+      return this.item.institutions.join(', ');
     },
     lastUpdated() {
       const date = new Date(this.item.lastUpdated * 1000);

--- a/src/components/filters/PbFilters.vue
+++ b/src/components/filters/PbFilters.vue
@@ -63,7 +63,7 @@ export default {
         },
         {
           component: 'pb-selectable-filters',
-          props: { title: 'Institution', field: 'institutionName', 'data-cy': 'institutions-filter', searchable: true }
+          props: { title: 'Institution', field: 'institutionName', 'data-cy': 'institution-filter', searchable: true }
         },
         {
           component: 'pb-selectable-filters',
@@ -76,7 +76,7 @@ export default {
         {
           component: 'pb-numeric-filters',
           props: { title: 'H5P Activities', field: 'h5pActivities', 'data-cy': 'h5p-filter' }
-        },
+        }
       ]
     };
   }

--- a/src/components/filters/PbFilters.vue
+++ b/src/components/filters/PbFilters.vue
@@ -63,7 +63,7 @@ export default {
         },
         {
           component: 'pb-selectable-filters',
-          props: { title: 'Institution', field: 'institutionName', 'data-cy': 'institution-filter', searchable: true }
+          props: { title: 'Institution', field: 'institutions', 'data-cy': 'institution-filter', searchable: true }
         },
         {
           component: 'pb-selectable-filters',

--- a/src/components/filters/PbFilters.vue
+++ b/src/components/filters/PbFilters.vue
@@ -63,6 +63,10 @@ export default {
         },
         {
           component: 'pb-selectable-filters',
+          props: { title: 'Institution', field: 'institutionName', 'data-cy': 'institutions-filter', searchable: true }
+        },
+        {
+          component: 'pb-selectable-filters',
           props: { title: 'Publisher', field: 'publisherName', 'data-cy': 'publisher-filter', searchable: true }
         },
         {

--- a/src/store/modules/searchclient.js
+++ b/src/store/modules/searchclient.js
@@ -63,6 +63,12 @@ let sClient = {
       empty: 'hasLanguageName',
       search: true
     },
+    institutionName: {
+      type: 'string',
+      alias: 'inst',
+      empty: 'hasInstitutions',
+      search: true
+    },
     publisherName: {
       type: 'string',
       alias: 'pub',

--- a/src/store/modules/searchclient.js
+++ b/src/store/modules/searchclient.js
@@ -63,7 +63,7 @@ let sClient = {
       empty: 'hasLanguageName',
       search: true
     },
-    institutionName: {
+    institutions: {
       type: 'string',
       alias: 'inst',
       empty: 'hasInstitutions',

--- a/src/store/modules/stats.js
+++ b/src/store/modules/stats.js
@@ -17,6 +17,8 @@ let stats = {
     'hasLanguageName',
     'hasPublisher',
     'hasNetworkName',
+    'hasInstitutions',
+    'institutions',
     'collections'
   ],
   filters: {},


### PR DESCRIPTION
Fix for #443. Add a searchable 'Institution' filter and display Institution(s): on the book card itself, just above publisher, when present.