### PR TITLE
fix: reset query on feature collection click

### DIFF
--- a/src/components/collections/PbCollectionCard.vue
+++ b/src/components/collections/PbCollectionCard.vue
@@ -63,14 +63,14 @@ export default {
         return;
       }
       
-      const { per_page } = this.$route.query;
+      const {per_page} = query;
 
       this.sendClickInsight();
+
       this.$router.replace({
         query: {
           [this.alias]: this.card.name,
           per_page,
-          q:[]
         }
       });
     },

--- a/src/components/forms/PbSearchBox.vue
+++ b/src/components/forms/PbSearchBox.vue
@@ -60,14 +60,18 @@ export default {
   },
   watch: {
     '$route.query.q' (q) {
+      this.stringSearch = '';
+
       if (typeof q === 'undefined') {
         this.$store.state.SClient.searchFilters = '';
         this.$store.state.SClient.searchParameters.searchQuery = '';
-        this.$store.state.SClient.filtersParams = (this.$store.state.SClient.hasNumeric) ?
-          this.$store.state.SClient.numericFilters : '';
-        return true;
+        this.$store.state.SClient.filtersParams = this.$store.state.SClient.hasNumeric 
+          ? this.$store.state.SClient.numericFilters 
+          : '';
+
+        return;
       }
-      this.stringSearch = '';
+
       if (q.length > 0) {
         this.stringSearch = q;
         let stringToSearch = this.filterSearch(q);
@@ -88,13 +92,13 @@ export default {
 
         this.$store.state.SClient.searchFilters = stringToSearch.facetFilters;
         this.$store.state.SClient.searchParameters.searchQuery = stringToSearch.stringSearch;
-        return true;
+
+        return;
       }
-      if (q.length === 0) {
-        let query = {...this.$route.query};
-        delete query.q;
-        this.$router.replace({ query });
-      }
+
+      let query = {...this.$route.query};
+      delete query.q;
+      this.$router.replace({ query });
     }
   },
   mounted() {


### PR DESCRIPTION
Issue #523 

This PR attempts to fix the search query not being properly cleared when clicking on a feature collection.

**How to test**

1. Checkout this branch
2. Visit the page and apply a search query
3. Click on any feature collection and make sure the search parameter is cleared from the URL + input search
4. Make sure the request to algolia does not contain the old search query
5. Remove the feature collection filter, the number of results should be the number of records in the index.

>**Note**
> There's a video that explains the issue in the ticket.
