### PR TITLE
feat: display links descriptions

### DIFF
--- a/e2e/integration/bookCards.cy.js
+++ b/e2e/integration/bookCards.cy.js
@@ -91,6 +91,14 @@ describe('Book cards', function () {
         .first()
         .should('include.text','Written specifically for students in Boise State University’s Bachelor of Applied Science');
     });
+    it('Search a book with a link within the description and check if it is rendered', () => {
+      search('Advanced Professional Communication');
+      cy.get(Elements.bookCards.description)
+          .first()
+          .should('include.text','supports the learning outcomes')
+          .contains('a', 'open textbook')
+          .should('have.attr', 'href', 'https://google.com#anchor1');
+    });
     it('Check all book card attributes from a particular book', () => {
       const attributesToCheck =  [
         {

--- a/src/components/VueClamp.vue
+++ b/src/components/VueClamp.vue
@@ -184,11 +184,17 @@ export default defineComponent({
       return false;
     },
     getText() {
-      // Look for the first non-empty text node
-      const [content] = (this.$slots.default() || []).filter(
-        (node) => !node.tag && !node.isComment
-      );
-      return content ? content.children : '';
+      const contents = this.$slots.default ? this.$slots.default() : [];
+      let text = '';
+      for (let i = 0; i < contents.length; i++) {
+        const node = contents[i];
+        if (!node.tag && !node.isComment && node.children) {
+          text += Array.isArray(node.children)
+            ? node.children.join('')
+            : [...node.children].join('');
+        }
+      }
+      return text;
     },
     moveEdge(steps) {
       this.clampAt(this.offset + steps);
@@ -198,7 +204,7 @@ export default defineComponent({
       this.applyChange();
     },
     applyChange() {
-      this.$refs.text.textContent = this.realText;
+      this.$refs.text.innerHTML = this.realText;
     },
     stepToFit() {
       this.fill();
@@ -238,6 +244,7 @@ export default defineComponent({
     },
   },
   render() {
+    // apply pb-red text color if it contains a link
     const contents = [
       h(
         'span',
@@ -246,8 +253,10 @@ export default defineComponent({
           attrs: {
             'aria-label': this.text?.trim(),
           },
+          class: 'book-description',
+          innerHTML: this.realText,
         },
-        this.realText
+        []
       ),
     ];
 

--- a/src/components/VueClamp.vue
+++ b/src/components/VueClamp.vue
@@ -155,8 +155,7 @@ export default defineComponent({
     getLines() {
       const lineHeight = parseInt(getComputedStyle(this.$refs.content).lineHeight);
       const contentHeight = this.$refs.content.offsetHeight;
-      const lineCount = Math.round(contentHeight / lineHeight);
-      return lineCount;
+      return Math.round(contentHeight / lineHeight);
     },
     isOverflow() {
       if (!this.maxLines && !this.maxHeight) {
@@ -237,7 +236,6 @@ export default defineComponent({
     },
   },
   render() {
-    // apply pb-red text color if it contains a link
     const contents = [
       h(
         'span',

--- a/src/components/VueClamp.vue
+++ b/src/components/VueClamp.vue
@@ -153,17 +153,10 @@ export default defineComponent({
       this.localExpanded = !this.localExpanded;
     },
     getLines() {
-      return Object.keys(
-        Array.prototype.slice
-          .call(this.$refs.content.getClientRects())
-          .reduce((prev, { top, bottom }) => {
-            const key = `${top}/${bottom}`;
-            if (!prev[key]) {
-              prev[key] = true;
-            }
-            return prev;
-          }, {})
-      ).length;
+      const lineHeight = parseInt(getComputedStyle(this.$refs.content).lineHeight);
+      const contentHeight = this.$refs.content.offsetHeight;
+      const lineCount = Math.round(contentHeight / lineHeight);
+      return lineCount;
     },
     isOverflow() {
       if (!this.maxLines && !this.maxHeight) {

--- a/src/components/books/BookDetails.vue
+++ b/src/components/books/BookDetails.vue
@@ -48,7 +48,7 @@
     </div>
     <div data-cy="book-description">
       <vue-clamp
-        v-if="hasDescription && item.description"
+        v-if="hasDescription"
         autoresize
         :max-lines="maxLinesDescription"
         class="leading-relaxed font-serif"

--- a/src/components/books/BookDetails.vue
+++ b/src/components/books/BookDetails.vue
@@ -48,7 +48,7 @@
     </div>
     <div data-cy="book-description">
       <vue-clamp
-        v-if="hasDescription"
+        v-if="hasDescription && item.description"
         autoresize
         :max-lines="maxLinesDescription"
         class="leading-relaxed font-serif"

--- a/src/components/books/PbBooks.vue
+++ b/src/components/books/PbBooks.vue
@@ -63,7 +63,7 @@ export default {
       return helpers.functions.getLicenseIconAndAltByLicenseName(item.licenseName);
     },
     removeXMLTags(string) {
-      return string.replace(/(<\/?(a)[^>]*>)|<[^>]+>/ig, '$1');
+      return string.replace(/(<\/?(?:a|p|em|strong|ul|ol|li|u|span)[^>]*>)|<[^>]+>/ig, '$1');
     },
     getBookDescription(item) {
       if (!item.hasDescription && item.hasDisambiguatingDescription) {

--- a/src/components/books/PbBooks.vue
+++ b/src/components/books/PbBooks.vue
@@ -63,7 +63,7 @@ export default {
       return helpers.functions.getLicenseIconAndAltByLicenseName(item.licenseName);
     },
     removeXMLTags(string) {
-      return string.replace(/(<([^>]+)>)/gi, '');
+      return string.replace(/(<\/?(a)[^>]*>)|<[^>]+>/ig, '$1');
     },
     getBookDescription(item) {
       if (!item.hasDescription && item.hasDisambiguatingDescription) {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -30,3 +30,7 @@ ul#footer-menu > li {
     font-size: 14px;
     color: black;
 }
+
+.book-description a {
+    @apply text-pb-red underline;
+}


### PR DESCRIPTION
Issue: #410 

This PR allows rendering links within books' descriptions in the book card.

### Testing case
- Use `pressbooks_directory_e2e_by_last_updated` to ensure you can find a book with a link within the book description.
- Search by "Advanced Professional Communication", and you will find a book with a link in it.
- You should see a clickable link in the description.

To revisit: Styling work.